### PR TITLE
Refactor service DTOs and add API regression test

### DIFF
--- a/back-end/app/api/services_api.py
+++ b/back-end/app/api/services_api.py
@@ -1,14 +1,12 @@
 # app/api/services_api.py
 import uuid
 from typing import List
-from fastapi import APIRouter, Depends, Form, HTTPException, UploadFile, File, status
+from fastapi import APIRouter, Depends, Form, UploadFile, File, status
 from sqlmodel import Session
 
 from app.core.dependencies import get_db_session
-from app.models.services_model import Service
 from app.schemas.services_schema import (
-    ServiceCreate,
-    ServicePublic,
+    ServiceCreatePayload,
     ServicePublicWithDetails,
     ServiceUpdate,
 )
@@ -41,7 +39,7 @@ async def create_new_service(
     """
     Tạo một dịch vụ mới, bao gồm cả việc tải lên hình ảnh.
     """
-    service_in = ServiceCreate(
+    service_in = ServiceCreatePayload(
         name=name,
         description=description,
         price=price,
@@ -83,10 +81,9 @@ def get_service_by_id(
     service_id: uuid.UUID, session: Session = Depends(get_db_session)
 ):
     """Lấy thông tin chi tiết một dịch vụ bằng ID."""
-    service = services_service.get_service_by_id(db=session, service_id=service_id)
-    if not service:
-        raise HTTPException(status_code=404, detail="Không tìm thấy dịch vụ")
-    return service
+    return services_service.get_service_details_by_id(
+        db=session, service_id=service_id
+    )
 
 
 @router.delete("/{service_id}", status_code=status.HTTP_204_NO_CONTENT)

--- a/back-end/app/api/test_api.py
+++ b/back-end/app/api/test_api.py
@@ -6,5 +6,5 @@ router = APIRouter()
 
 
 @router.get("/test")
-async def test_endpoint():
+async def read_test_endpoint():
     return {"message": "Test endpoint is working!"}

--- a/back-end/app/schemas/services_schema.py
+++ b/back-end/app/schemas/services_schema.py
@@ -1,7 +1,9 @@
 # app/schemas/services_schema.py
-from typing import Optional, List
-from sqlmodel import SQLModel, Field
-import uuid
+from typing import List
+from uuid import UUID
+
+from pydantic import ConfigDict
+from sqlmodel import Field, SQLModel
 
 from app.schemas.catalog_schema import CategoryPublic, ImagePublic
 
@@ -17,12 +19,14 @@ class ServiceBase(SQLModel):
     aftercare_instructions: str | None
     contraindications: str | None
 
-    # THAY ĐỔI: Chấp nhận một danh sách các ID danh mục
-    category_ids: List[uuid.UUID] = Field(description="Danh sách ID của các danh mục")
 
+class ServiceCreatePayload(ServiceBase):
+    """Payload nhận từ request khi tạo dịch vụ mới."""
 
-class ServiceCreate(ServiceBase):
-    pass
+    category_ids: List[UUID] = Field(
+        default_factory=list, description="Danh sách ID của các danh mục"
+    )
+    model_config = ConfigDict(from_attributes=True)
 
 
 class ServiceUpdate(SQLModel):
@@ -33,18 +37,19 @@ class ServiceUpdate(SQLModel):
     preparation_notes: str | None = Field(default=None)
     aftercare_instructions: str | None = Field(default=None)
     contraindications: str | None = Field(default=None)
-    # THAY ĐỔI: Cho phép cập nhật danh sách danh mục
-    category_ids: List[uuid.UUID] | None = Field(default=None)
+    category_ids: List[UUID] | None = Field(default=None)
 
 
 class ServicePublic(ServiceBase):
-    id: uuid.UUID
+    id: UUID
+    categories: List[CategoryPublic] = Field(default_factory=list)
+    images: List[ImagePublic] = Field(default_factory=list)
+    model_config = ConfigDict(from_attributes=True)
 
 
 class ServicePublicWithDetails(ServicePublic):
-    # THAY ĐỔI: Hiển thị danh sách các danh mục
-    categories: List[CategoryPublic] = []
-    images: List[ImagePublic] = []
+    category_ids: List[UUID] = Field(default_factory=list)
+    model_config = ConfigDict(from_attributes=True)
 
 
 # Cần forward reference cho treatment plan schema

--- a/back-end/app/services/services_service.py
+++ b/back-end/app/services/services_service.py
@@ -6,7 +6,11 @@ from sqlmodel import Session, select
 
 from app.models.services_model import Service
 from app.models.catalog_model import Image, Category
-from app.schemas.services_schema import ServiceCreate, ServiceUpdate
+from app.schemas.services_schema import (
+    ServiceCreatePayload,
+    ServicePublicWithDetails,
+    ServiceUpdate,
+)
 from app.schemas.catalog_schema import CategoryTypeEnum
 from app.core import supabase_client
 from fastapi import UploadFile
@@ -14,9 +18,18 @@ from app.utils.common import get_object_or_404
 from app.services import catalog_service
 
 
+def _build_service_public_with_details(service: Service) -> ServicePublicWithDetails:
+    return ServicePublicWithDetails.model_validate(
+        service,
+        update={
+            "category_ids": [category.id for category in service.categories],
+        },
+    )
+
+
 async def create_service(
-    db: Session, service_in: ServiceCreate, images: List[UploadFile]
-) -> Service:
+    db: Session, service_in: ServiceCreatePayload, images: List[UploadFile]
+) -> ServicePublicWithDetails:
     """Tạo mới một dịch vụ, liên kết với nhiều danh mục và tải hình ảnh."""
     # 1. Kiểm tra sự tồn tại của các danh mục
     categories = []
@@ -76,12 +89,12 @@ async def create_service(
         db.commit()
         db.refresh(db_service)
 
-    return db_service
+    return _build_service_public_with_details(db_service)
 
 
 def update_service(
     db: Session, db_service: Service, service_in: ServiceUpdate
-) -> Service:
+) -> ServicePublicWithDetails:
     """Cập nhật thông tin dịch vụ, bao gồm cả danh sách danh mục."""
     service_data = service_in.model_dump(exclude_unset=True)
 
@@ -106,21 +119,31 @@ def update_service(
     db.add(db_service)
     db.commit()
     db.refresh(db_service)
-    return db_service
+    return _build_service_public_with_details(db_service)
 
 
 # ... (các hàm get_all_services, get_service_by_id, delete_service giữ nguyên)
-def get_all_services(db: Session, skip: int = 0, limit: int = 100) -> List[Service]:
+def get_all_services(
+    db: Session, skip: int = 0, limit: int = 100
+) -> List[ServicePublicWithDetails]:
     """Lấy danh sách tất cả dịch vụ CHƯA BỊ XÓA."""
     services = db.exec(
         select(Service).where(Service.is_deleted == False).offset(skip).limit(limit)
     ).all()
-    return services
+    return [_build_service_public_with_details(service) for service in services]
 
 
 def get_service_by_id(db: Session, service_id: uuid.UUID) -> Service:
     """Lấy dịch vụ bằng ID, đảm bảo nó tồn tại và chưa bị xóa."""
     return get_object_or_404(db, model=Service, obj_id=service_id)
+
+
+def get_service_details_by_id(
+    db: Session, service_id: uuid.UUID
+) -> ServicePublicWithDetails:
+    """Trả về DTO chi tiết của một dịch vụ."""
+    service = get_service_by_id(db=db, service_id=service_id)
+    return _build_service_public_with_details(service)
 
 
 def delete_service(db: Session, db_service: Service) -> Service:

--- a/back-end/tests/test_services_api.py
+++ b/back-end/tests/test_services_api.py
@@ -1,0 +1,119 @@
+import os
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.pool import StaticPool
+from sqlmodel import Session, SQLModel, create_engine
+
+os.environ.setdefault("DATABASE_URL", "sqlite://")
+os.environ.setdefault("SECRET_KEY", "secret")
+os.environ.setdefault("ALGORITHM", "HS256")
+os.environ.setdefault("ACCESS_TOKEN_EXPIRE_MINUTES", "30")
+os.environ.setdefault("MAIL_USERNAME", "test@example.com")
+os.environ.setdefault("MAIL_PASSWORD", "password")
+os.environ.setdefault("MAIL_FROM", "test@example.com")
+os.environ.setdefault("MAIL_PORT", "1025")
+os.environ.setdefault("MAIL_SERVER", "localhost")
+os.environ.setdefault("MAIL_STARTTLS", "false")
+os.environ.setdefault("MAIL_SSL_TLS", "false")
+os.environ.setdefault("GOOGLE_CLIENT_ID", "client")
+os.environ.setdefault("GOOGLE_CLIENT_SECRET", "secret")
+os.environ.setdefault("BACKEND_CORS_ORIGINS", "[\"*\"]")
+os.environ.setdefault("SUPABASE_URL", "http://localhost")
+os.environ.setdefault("SUPABASE_KEY", "key")
+os.environ.setdefault("SUPABASE_BUCKET_NAME", "bucket")
+
+from app.core import supabase_client
+from app.core.dependencies import get_db_session
+from app.main import app
+from app.models.catalog_model import Category
+from app.schemas.catalog_schema import CategoryTypeEnum
+
+
+@pytest.fixture(name="engine")
+def engine_fixture():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SQLModel.metadata.create_all(engine)
+    try:
+        yield engine
+    finally:
+        SQLModel.metadata.drop_all(engine)
+
+
+@pytest.fixture(name="client")
+def client_fixture(engine):
+    def get_session_override():
+        with Session(engine) as session:
+            yield session
+
+    app.dependency_overrides[get_db_session] = get_session_override
+    original_upload_image = supabase_client.upload_image
+
+    async def fake_upload_image(file, file_name=None):
+        return None
+
+    supabase_client.upload_image = fake_upload_image
+    try:
+        with TestClient(app) as client:
+            yield client
+    finally:
+        supabase_client.upload_image = original_upload_image
+        app.dependency_overrides.clear()
+
+
+def test_get_services_returns_valid_payload(client, engine):
+    # Arrange
+    with Session(engine) as session:
+        category_1 = Category(
+            name="Massage",
+            description="Thư giãn",
+            category_type=CategoryTypeEnum.service.value,
+        )
+        category_2 = Category(
+            name="Facial",
+            description="Chăm sóc da",
+            category_type=CategoryTypeEnum.service.value,
+        )
+        session.add(category_1)
+        session.add(category_2)
+        session.commit()
+        session.refresh(category_1)
+        session.refresh(category_2)
+
+        category_ids = [str(category_1.id), str(category_2.id)]
+
+    multipart_form = [
+        ("name", (None, "Dịch vụ thư giãn")),
+        ("description", (None, "Mô tả dịch vụ")),
+        ("price", (None, "150000")),
+        ("duration_minutes", (None, "60")),
+        ("category_ids", (None, category_ids[0])),
+        ("category_ids", (None, category_ids[1])),
+        ("preparation_notes", (None, "Chuẩn bị")),
+        ("aftercare_instructions", (None, "Chăm sóc")),
+        ("contraindications", (None, "Chống chỉ định")),
+        ("images", ("test.jpg", b"fake", "image/jpeg")),
+    ]
+
+    create_response = client.post("/services", files=multipart_form)
+    assert create_response.status_code == 201, create_response.text
+
+    # Act
+    list_response = client.get("/services")
+
+    # Assert
+    assert list_response.status_code == 200, list_response.text
+    payload = list_response.json()
+    assert isinstance(payload, list)
+    assert len(payload) == 1
+
+    service = payload[0]
+    assert set(service["category_ids"]) == set(category_ids)
+    assert len(service["categories"]) == 2
+    assert {item["id"] for item in service["categories"]} == set(category_ids)
+    assert "images" in service
+    assert isinstance(service["images"], list)


### PR DESCRIPTION
## Summary
- refactor the service schemas to separate request payloads from DTOs and ensure list defaults use `default_factory`
- update the service service layer and API endpoints to build normalized response DTOs populated from relationships
- rename the sample test endpoint handler to avoid pytest collection and add an integration test covering the /services workflow

## Testing
- `cd back-end && pytest`


------
https://chatgpt.com/codex/tasks/task_e_68e20f84e774832890aafc0335a495a4