### PR TITLE
Fix schema list defaults and add regression tests

### DIFF
--- a/back-end/app/schemas/catalog_schema.py
+++ b/back-end/app/schemas/catalog_schema.py
@@ -1,6 +1,6 @@
 # app/schemas/catalog_schema.py
 import uuid
-from typing import List, Optional, Any
+from typing import Any, Optional
 from sqlmodel import SQLModel, Field
 from enum import Enum
 
@@ -47,5 +47,7 @@ class CategoryPublic(CategoryBase):
 
 
 class CategoryPublicWithItems(CategoryPublic):
+    model_config = {"from_attributes": True}
+
     # Dùng Any để linh hoạt, sẽ được thay thế ở các schema con
-    items: List[Any] = []
+    items: list[Any] = Field(default_factory=list)

--- a/back-end/app/schemas/products_schema.py
+++ b/back-end/app/schemas/products_schema.py
@@ -1,6 +1,6 @@
 # app/schemas/products_schema.py
 import uuid
-from typing import List, Optional
+from typing import Optional
 from sqlmodel import SQLModel, Field
 from app.schemas.catalog_schema import CategoryPublic, ImagePublic
 
@@ -36,5 +36,7 @@ class ProductPublic(ProductBase):
 
 
 class ProductPublicWithDetails(ProductPublic):
+    model_config = {"from_attributes": True}
+
     category: CategoryPublic
-    images: List[ImagePublic] = []
+    images: list[ImagePublic] = Field(default_factory=list)

--- a/back-end/app/schemas/roles_schema.py
+++ b/back-end/app/schemas/roles_schema.py
@@ -1,6 +1,6 @@
 # app/schemas/roles_schema.py
 import uuid
-from typing import List
+
 from sqlmodel import Field, SQLModel
 
 
@@ -42,7 +42,9 @@ class RolePublic(RoleBase):
 
 
 class RolePublicWithPermissions(RolePublic):
-    permissions: List[PermissionPublic] = []
+    model_config = {"from_attributes": True}
+
+    permissions: list[PermissionPublic] = Field(default_factory=list)
 
 
 class AssignPermissionToRole(SQLModel):

--- a/back-end/app/schemas/services_schema.py
+++ b/back-end/app/schemas/services_schema.py
@@ -1,5 +1,5 @@
 # app/schemas/services_schema.py
-from typing import Optional, List
+from typing import Optional
 from sqlmodel import SQLModel, Field
 import uuid
 
@@ -18,7 +18,7 @@ class ServiceBase(SQLModel):
     contraindications: str | None
 
     # THAY ĐỔI: Chấp nhận một danh sách các ID danh mục
-    category_ids: List[uuid.UUID] = Field(description="Danh sách ID của các danh mục")
+    category_ids: list[uuid.UUID] = Field(description="Danh sách ID của các danh mục")
 
 
 class ServiceCreate(ServiceBase):
@@ -34,7 +34,7 @@ class ServiceUpdate(SQLModel):
     aftercare_instructions: str | None = Field(default=None)
     contraindications: str | None = Field(default=None)
     # THAY ĐỔI: Cho phép cập nhật danh sách danh mục
-    category_ids: List[uuid.UUID] | None = Field(default=None)
+    category_ids: list[uuid.UUID] | None = Field(default=None)
 
 
 class ServicePublic(ServiceBase):
@@ -42,9 +42,11 @@ class ServicePublic(ServiceBase):
 
 
 class ServicePublicWithDetails(ServicePublic):
+    model_config = {"from_attributes": True}
+
     # THAY ĐỔI: Hiển thị danh sách các danh mục
-    categories: List[CategoryPublic] = []
-    images: List[ImagePublic] = []
+    categories: list[CategoryPublic] = Field(default_factory=list)
+    images: list[ImagePublic] = Field(default_factory=list)
 
 
 # Cần forward reference cho treatment plan schema

--- a/back-end/app/schemas/treatment_plans_schema.py
+++ b/back-end/app/schemas/treatment_plans_schema.py
@@ -1,6 +1,6 @@
 # app/schemas/treatment_plans_schema.py
 import uuid
-from typing import List, Optional
+from typing import Optional
 from sqlmodel import SQLModel, Field
 from app.schemas.catalog_schema import CategoryPublic, ImagePublic
 
@@ -28,7 +28,7 @@ class TreatmentPlanBase(SQLModel):
 
 
 class TreatmentPlanCreate(TreatmentPlanBase):
-    steps: List[TreatmentPlanStepBase] = []
+    steps: list[TreatmentPlanStepBase] = Field(default_factory=list)
 
 
 class TreatmentPlanUpdate(SQLModel):
@@ -44,6 +44,8 @@ class TreatmentPlanPublic(TreatmentPlanBase):
 
 
 class TreatmentPlanPublicWithDetails(TreatmentPlanPublic):
+    model_config = {"from_attributes": True}
+
     category: CategoryPublic
-    images: List[ImagePublic] = []
-    steps: List[TreatmentPlanStepPublic] = []
+    images: list[ImagePublic] = Field(default_factory=list)
+    steps: list[TreatmentPlanStepPublic] = Field(default_factory=list)

--- a/back-end/app/schemas/users_schema.py
+++ b/back-end/app/schemas/users_schema.py
@@ -2,7 +2,7 @@
 
 import uuid
 import re
-from typing import List, Optional
+from typing import Optional
 
 from pydantic import EmailStr, Field, field_validator
 from sqlmodel import SQLModel
@@ -99,7 +99,9 @@ class UserUpdateByAdmin(SQLModel):
 
 # Schema hiển thị thông tin người dùng KÈM THEO vai trò và quyền của họ
 class UserPublicWithRolesAndPermissions(UserPublic):
-    roles: List[RolePublicWithPermissions] = []
+    model_config = {"from_attributes": True}
+
+    roles: list[RolePublicWithPermissions] = Field(default_factory=list)
 
 
 # Cập nhật tham chiếu

--- a/back-end/tests/test_schema_list_defaults.py
+++ b/back-end/tests/test_schema_list_defaults.py
@@ -1,0 +1,146 @@
+import uuid
+
+import pytest
+
+from app.schemas.catalog_schema import CategoryPublic, CategoryPublicWithItems
+from app.schemas.products_schema import ProductPublicWithDetails
+from app.schemas.roles_schema import RolePublicWithPermissions
+from app.schemas.services_schema import ServicePublicWithDetails
+from app.schemas.treatment_plans_schema import (
+    TreatmentPlanCreate,
+    TreatmentPlanPublicWithDetails,
+)
+from app.schemas.users_schema import UserPublicWithRolesAndPermissions
+
+
+# Helper factories to keep the parametrization concise
+
+def make_category_public() -> CategoryPublic:
+    return CategoryPublic(
+        id=uuid.uuid4(),
+        name="Category",
+        description=None,
+        category_type="service",
+    )
+
+
+def make_service_kwargs() -> dict:
+    return {
+        "id": uuid.uuid4(),
+        "name": "Service",
+        "description": "Desc",
+        "price": 100.0,
+        "duration_minutes": 60,
+        "preparation_notes": None,
+        "aftercare_instructions": None,
+        "contraindications": None,
+        "category_ids": [uuid.uuid4()],
+    }
+
+
+def make_treatment_plan_kwargs() -> dict:
+    return {
+        "id": uuid.uuid4(),
+        "name": "Plan",
+        "description": "Desc",
+        "price": 100.0,
+        "total_sessions": 5,
+        "category_id": uuid.uuid4(),
+    }
+
+
+def make_product_kwargs() -> dict:
+    return {
+        "id": uuid.uuid4(),
+        "name": "Product",
+        "description": "Desc",
+        "price": 10.0,
+        "stock": 1,
+        "is_retail": True,
+        "is_consumable": False,
+        "base_unit": "unit",
+        "consumable_unit": None,
+        "conversion_rate": None,
+        "category_id": uuid.uuid4(),
+    }
+
+
+@pytest.mark.parametrize(
+    "model_cls, kwargs_factory, list_fields",
+    [
+        (
+            UserPublicWithRolesAndPermissions,
+            lambda: {
+                "id": uuid.uuid4(),
+                "email": f"user-{uuid.uuid4()}@example.com",
+                "phone": None,
+                "full_name": None,
+                "is_active": True,
+                "is_superuser": False,
+            },
+            ("roles",),
+        ),
+        (
+            RolePublicWithPermissions,
+            lambda: {
+                "id": uuid.uuid4(),
+                "name": "role",
+                "description": None,
+            },
+            ("permissions",),
+        ),
+        (
+            ServicePublicWithDetails,
+            lambda: make_service_kwargs(),
+            ("categories", "images"),
+        ),
+        (
+            TreatmentPlanCreate,
+            lambda: {
+                "name": "Plan",
+                "description": "Desc",
+                "price": 100.0,
+                "total_sessions": 5,
+                "category_id": uuid.uuid4(),
+            },
+            ("steps",),
+        ),
+        (
+            TreatmentPlanPublicWithDetails,
+            lambda: {
+                **make_treatment_plan_kwargs(),
+                "category": make_category_public(),
+            },
+            ("images", "steps"),
+        ),
+        (
+            ProductPublicWithDetails,
+            lambda: {
+                **make_product_kwargs(),
+                "category": make_category_public(),
+            },
+            ("images",),
+        ),
+        (
+            CategoryPublicWithItems,
+            lambda: {
+                "id": uuid.uuid4(),
+                "name": "Category",
+                "description": None,
+                "category_type": "service",
+            },
+            ("items",),
+        ),
+    ],
+)
+def test_schema_list_defaults_are_independent(model_cls, kwargs_factory, list_fields):
+    instance_a = model_cls(**kwargs_factory())
+    instance_b = model_cls(**kwargs_factory())
+
+    for field in list_fields:
+        list_a = getattr(instance_a, field)
+        list_b = getattr(instance_b, field)
+
+        assert list_a == []
+        assert list_b == []
+        assert list_a is not list_b


### PR DESCRIPTION
## Summary
- replace mutable default list values in schema responses with `Field(default_factory=list)` and switch list hints to builtin generics
- enable `from_attributes` on composite response schemas to support ORM model hydration
- add regression coverage ensuring each schema instance starts with an independent empty list

## Testing
- pytest *(fails: existing async API test requires an async-aware pytest plugin)*
- PYTHONPATH=. pytest tests/test_schema_list_defaults.py


------
https://chatgpt.com/codex/tasks/task_e_68e20fb285508328ba91e9de5f4a29ff