### PR TITLE
Add service layers for products and treatment plans

### DIFF
--- a/back-end/app/api/test_api.py
+++ b/back-end/app/api/test_api.py
@@ -6,5 +6,5 @@ router = APIRouter()
 
 
 @router.get("/test")
-async def test_endpoint():
+async def get_test_endpoint():
     return {"message": "Test endpoint is working!"}

--- a/back-end/app/models/services_model.py
+++ b/back-end/app/models/services_model.py
@@ -39,3 +39,11 @@ class Service(BaseUUIDModel, table=True):
     )
 
     images: List["Image"] = Relationship(back_populates="service")
+
+    @property
+    def category_ids(self) -> List[uuid.UUID]:
+        """Danh sách ID của các danh mục không bị xóa mềm."""
+
+        return [
+            category.id for category in self.categories if not category.is_deleted
+        ]

--- a/back-end/app/services/products_service.py
+++ b/back-end/app/services/products_service.py
@@ -1,0 +1,140 @@
+# app/services/products_service.py
+import uuid
+from typing import List
+
+from fastapi import HTTPException, status
+from sqlalchemy.orm import selectinload
+from sqlmodel import Session, select
+
+from app.models.catalog_model import Category
+from app.models.products_model import Product
+from app.schemas.catalog_schema import CategoryTypeEnum
+from app.schemas.products_schema import ProductCreate, ProductUpdate
+from app.services import catalog_service
+
+
+def _with_product_relationships(statement):
+    """Helper để load category và images cho product."""
+
+    return statement.options(
+        selectinload(Product.category),
+        selectinload(Product.images),
+    )
+
+
+def _ensure_product_category(category: Category) -> None:
+    """Đảm bảo danh mục được gán cho sản phẩm là loại product."""
+
+    if category.category_type != CategoryTypeEnum.product:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Danh mục được chọn không phải danh mục sản phẩm.",
+        )
+
+
+def _filter_soft_deleted_relationships(product: Product) -> Product:
+    """Loại bỏ các quan hệ đã bị xóa mềm trước khi trả về."""
+
+    product.images = [image for image in product.images if not image.is_deleted]
+    return product
+
+
+def create_product(db: Session, product_in: ProductCreate) -> Product:
+    """Tạo mới một sản phẩm."""
+
+    category = catalog_service.get_category_by_id(db, product_in.category_id)
+    _ensure_product_category(category)
+
+    existing_product = db.exec(
+        select(Product).where(
+            Product.name == product_in.name, Product.is_deleted == False
+        )
+    ).first()
+    if existing_product:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Sản phẩm với tên '{product_in.name}' đã tồn tại.",
+        )
+
+    db_product = Product(**product_in.model_dump())
+    db.add(db_product)
+    db.commit()
+    db.refresh(db_product)
+
+    return get_product_by_id(db, db_product.id)
+
+
+def get_all_products(db: Session, skip: int = 0, limit: int = 100) -> List[Product]:
+    """Lấy danh sách sản phẩm chưa bị xóa mềm."""
+
+    statement = _with_product_relationships(
+        select(Product)
+        .where(Product.is_deleted == False)
+        .offset(skip)
+        .limit(limit)
+    )
+    products = db.exec(statement).unique().all()
+    return [_filter_soft_deleted_relationships(product) for product in products]
+
+
+def get_product_by_id(db: Session, product_id: uuid.UUID) -> Product:
+    """Lấy thông tin chi tiết của một sản phẩm."""
+
+    statement = _with_product_relationships(
+        select(Product).where(
+            Product.id == product_id,
+            Product.is_deleted == False,
+        )
+    )
+    product = db.exec(statement).unique().first()
+    if not product:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Product với ID {product_id} không được tìm thấy.",
+        )
+    return _filter_soft_deleted_relationships(product)
+
+
+def update_product(
+    db: Session, db_product: Product, product_in: ProductUpdate
+) -> Product:
+    """Cập nhật thông tin một sản phẩm."""
+
+    product_data = product_in.model_dump(exclude_unset=True)
+
+    if "name" in product_data:
+        existing_product = db.exec(
+            select(Product).where(
+                Product.name == product_data["name"],
+                Product.id != db_product.id,
+                Product.is_deleted == False,
+            )
+        ).first()
+        if existing_product:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Sản phẩm với tên '{product_data['name']}' đã tồn tại.",
+            )
+
+    if "category_id" in product_data and product_data["category_id"]:
+        category = catalog_service.get_category_by_id(db, product_data["category_id"])
+        _ensure_product_category(category)
+
+    for key, value in product_data.items():
+        setattr(db_product, key, value)
+
+    db.add(db_product)
+    db.commit()
+    db.refresh(db_product)
+
+    return get_product_by_id(db, db_product.id)
+
+
+def delete_product(db: Session, db_product: Product) -> Product:
+    """Xóa mềm một sản phẩm."""
+
+    db_product.is_deleted = True
+    db.add(db_product)
+    db.commit()
+    db.refresh(db_product)
+    return db_product

--- a/back-end/app/services/treatment_plans_service.py
+++ b/back-end/app/services/treatment_plans_service.py
@@ -1,0 +1,172 @@
+# app/services/treatment_plans_service.py
+import uuid
+from typing import List
+
+from fastapi import HTTPException, status
+from sqlalchemy.orm import selectinload
+from sqlmodel import Session, select
+
+from app.models.catalog_model import Category
+from app.models.treatment_plans_model import TreatmentPlan, TreatmentPlanStep
+from app.models.services_model import Service
+from app.schemas.catalog_schema import CategoryTypeEnum
+from app.schemas.treatment_plans_schema import (
+    TreatmentPlanCreate,
+    TreatmentPlanUpdate,
+)
+from app.services import catalog_service, services_service
+
+
+def _with_treatment_plan_relationships(statement):
+    """Helper để load đầy đủ các quan hệ cho treatment plan."""
+
+    return statement.options(
+        selectinload(TreatmentPlan.category),
+        selectinload(TreatmentPlan.images),
+        selectinload(TreatmentPlan.steps)
+        .selectinload(TreatmentPlanStep.service)
+        .selectinload(Service.categories),
+    )
+
+
+def _ensure_treatment_plan_category(category: Category) -> None:
+    if category.category_type != CategoryTypeEnum.treatment_plan:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Danh mục được chọn không phải danh mục liệu trình.",
+        )
+
+
+def _filter_soft_deleted_relationships(
+    treatment_plan: TreatmentPlan,
+) -> TreatmentPlan:
+    treatment_plan.images = [
+        image for image in treatment_plan.images if not image.is_deleted
+    ]
+    filtered_steps: List[TreatmentPlanStep] = []
+    for step in treatment_plan.steps:
+        if step.is_deleted:
+            continue
+        if step.service and step.service.is_deleted:
+            continue
+        if step.service:
+            step.service.categories = [
+                category for category in step.service.categories if not category.is_deleted
+            ]
+        filtered_steps.append(step)
+    treatment_plan.steps = filtered_steps
+    return treatment_plan
+
+
+def create_treatment_plan(
+    db: Session, treatment_plan_in: TreatmentPlanCreate
+) -> TreatmentPlan:
+    """Tạo mới một treatment plan cùng với các bước."""
+
+    category = catalog_service.get_category_by_id(db, treatment_plan_in.category_id)
+    _ensure_treatment_plan_category(category)
+
+    existing_plan = db.exec(
+        select(TreatmentPlan).where(
+            TreatmentPlan.name == treatment_plan_in.name,
+            TreatmentPlan.is_deleted == False,
+        )
+    ).first()
+    if existing_plan:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Liệu trình '{treatment_plan_in.name}' đã tồn tại.",
+        )
+
+    for step_in in treatment_plan_in.steps:
+        services_service.get_service_by_id(db, step_in.service_id)
+
+    plan_data = treatment_plan_in.model_dump(exclude={"steps"})
+    db_plan = TreatmentPlan(**plan_data)
+    db.add(db_plan)
+    db.commit()
+    db.refresh(db_plan)
+
+    for step_in in treatment_plan_in.steps:
+        db_step = TreatmentPlanStep(
+            **step_in.model_dump(), treatment_plan_id=db_plan.id
+        )
+        db.add(db_step)
+
+    db.commit()
+    return get_treatment_plan_by_id(db, db_plan.id)
+
+
+def get_all_treatment_plans(
+    db: Session, skip: int = 0, limit: int = 100
+) -> List[TreatmentPlan]:
+    statement = _with_treatment_plan_relationships(
+        select(TreatmentPlan)
+        .where(TreatmentPlan.is_deleted == False)
+        .offset(skip)
+        .limit(limit)
+    )
+    treatment_plans = db.exec(statement).unique().all()
+    return [
+        _filter_soft_deleted_relationships(treatment_plan)
+        for treatment_plan in treatment_plans
+    ]
+
+
+def get_treatment_plan_by_id(
+    db: Session, treatment_plan_id: uuid.UUID
+) -> TreatmentPlan:
+    statement = _with_treatment_plan_relationships(
+        select(TreatmentPlan).where(
+            TreatmentPlan.id == treatment_plan_id,
+            TreatmentPlan.is_deleted == False,
+        )
+    )
+    treatment_plan = db.exec(statement).unique().first()
+    if not treatment_plan:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"TreatmentPlan với ID {treatment_plan_id} không được tìm thấy.",
+        )
+    return _filter_soft_deleted_relationships(treatment_plan)
+
+
+def update_treatment_plan(
+    db: Session, db_treatment_plan: TreatmentPlan, treatment_plan_in: TreatmentPlanUpdate
+) -> TreatmentPlan:
+    plan_data = treatment_plan_in.model_dump(exclude_unset=True)
+
+    if "name" in plan_data:
+        existing_plan = db.exec(
+            select(TreatmentPlan).where(
+                TreatmentPlan.name == plan_data["name"],
+                TreatmentPlan.id != db_treatment_plan.id,
+                TreatmentPlan.is_deleted == False,
+            )
+        ).first()
+        if existing_plan:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Liệu trình '{plan_data['name']}' đã tồn tại.",
+            )
+
+    if "category_id" in plan_data and plan_data["category_id"]:
+        category = catalog_service.get_category_by_id(db, plan_data["category_id"])
+        _ensure_treatment_plan_category(category)
+
+    for key, value in plan_data.items():
+        setattr(db_treatment_plan, key, value)
+
+    db.add(db_treatment_plan)
+    db.commit()
+    db.refresh(db_treatment_plan)
+
+    return get_treatment_plan_by_id(db, db_treatment_plan.id)
+
+
+def delete_treatment_plan(db: Session, db_treatment_plan: TreatmentPlan) -> TreatmentPlan:
+    db_treatment_plan.is_deleted = True
+    db.add(db_treatment_plan)
+    db.commit()
+    db.refresh(db_treatment_plan)
+    return db_treatment_plan

--- a/back-end/tests/conftest.py
+++ b/back-end/tests/conftest.py
@@ -1,0 +1,70 @@
+import os
+from typing import Generator
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.pool import StaticPool
+from sqlmodel import Session, SQLModel, create_engine
+
+# Đặt các biến môi trường cần thiết trước khi import ứng dụng
+os.environ.setdefault("DATABASE_URL", "sqlite:///test.db")
+os.environ.setdefault("SECRET_KEY", "test")
+os.environ.setdefault("ALGORITHM", "HS256")
+os.environ.setdefault("ACCESS_TOKEN_EXPIRE_MINUTES", "30")
+os.environ.setdefault("MAIL_USERNAME", "test@example.com")
+os.environ.setdefault("MAIL_PASSWORD", "secret")
+os.environ.setdefault("MAIL_FROM", "test@example.com")
+os.environ.setdefault("MAIL_PORT", "587")
+os.environ.setdefault("MAIL_SERVER", "smtp.example.com")
+os.environ.setdefault("MAIL_STARTTLS", "False")
+os.environ.setdefault("MAIL_SSL_TLS", "False")
+os.environ.setdefault("GOOGLE_CLIENT_ID", "client-id")
+os.environ.setdefault("GOOGLE_CLIENT_SECRET", "client-secret")
+os.environ.setdefault("BACKEND_CORS_ORIGINS", '["*"]')
+os.environ.setdefault("SUPABASE_URL", "http://localhost")
+os.environ.setdefault("SUPABASE_KEY", "supabase-key")
+os.environ.setdefault("SUPABASE_BUCKET_NAME", "bucket")
+
+from app.core.dependencies import get_db_session  # noqa: E402
+from app.main import app  # noqa: E402
+
+# Import models để đảm bảo SQLModel biết tất cả bảng
+from app.models import association_tables  # noqa: F401
+from app.models import catalog_model  # noqa: F401
+from app.models import products_model  # noqa: F401
+from app.models import schedules_model  # noqa: F401
+from app.models import services_model  # noqa: F401
+from app.models import treatment_plans_model  # noqa: F401
+from app.models import users_model  # noqa: F401
+
+
+@pytest.fixture(name="engine")
+def engine_fixture():
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SQLModel.metadata.create_all(engine)
+    try:
+        yield engine
+    finally:
+        SQLModel.metadata.drop_all(engine)
+
+
+@pytest.fixture(name="session")
+def session_fixture(engine) -> Generator[Session, None, None]:
+    with Session(engine) as session:
+        yield session
+
+
+@pytest.fixture(name="client")
+def client_fixture(engine):
+    def _get_test_session():
+        with Session(engine) as session:
+            yield session
+
+    app.dependency_overrides[get_db_session] = _get_test_session
+    with TestClient(app) as client:
+        yield client
+    app.dependency_overrides.clear()

--- a/back-end/tests/test_products_api.py
+++ b/back-end/tests/test_products_api.py
@@ -1,0 +1,53 @@
+import uuid
+
+from app.models.catalog_model import Category, Image
+from app.models.products_model import Product
+from app.schemas.catalog_schema import CategoryTypeEnum
+
+
+def test_get_all_products_returns_data(client, session):
+    category = Category(
+        name="Chăm sóc da",
+        description="Danh mục sản phẩm",
+        category_type=CategoryTypeEnum.product,
+    )
+    session.add(category)
+    session.commit()
+    session.refresh(category)
+
+    product = Product(
+        name="Sữa rửa mặt",
+        description="Làm sạch dịu nhẹ",
+        price=120000,
+        stock=10,
+        is_retail=True,
+        is_consumable=False,
+        base_unit="chai",
+        category_id=category.id,
+    )
+    session.add(product)
+    session.commit()
+    session.refresh(product)
+
+    image = Image(
+        url="https://example.com/image.jpg",
+        alt_text="Sản phẩm",
+        is_primary=True,
+        product_id=product.id,
+    )
+    session.add(image)
+    session.commit()
+
+    response = client.get("/products")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["id"] == str(product.id)
+    assert data[0]["category"]["id"] == str(category.id)
+    assert data[0]["images"][0]["url"] == image.url
+
+
+def test_get_product_not_found_returns_404(client):
+    response = client.get(f"/products/{uuid.uuid4()}")
+    assert response.status_code == 404
+    assert "Product" in response.json()["detail"]

--- a/back-end/tests/test_treatment_plans_api.py
+++ b/back-end/tests/test_treatment_plans_api.py
@@ -1,0 +1,89 @@
+import uuid
+
+from app.models.catalog_model import Category, Image
+from app.models.services_model import Service
+from app.models.treatment_plans_model import TreatmentPlan, TreatmentPlanStep
+from app.schemas.catalog_schema import CategoryTypeEnum
+
+
+def _create_service(session) -> Service:
+    service_category = Category(
+        name="Chăm sóc da",
+        description="Danh mục dịch vụ",
+        category_type=CategoryTypeEnum.service,
+    )
+    session.add(service_category)
+    session.commit()
+    session.refresh(service_category)
+
+    service = Service(
+        name="Làm sạch da",
+        description="Dịch vụ làm sạch",
+        price=250000,
+        duration_minutes=60,
+        preparation_notes=None,
+        aftercare_instructions=None,
+        contraindications=None,
+    )
+    service.categories.append(service_category)
+    session.add(service)
+    session.commit()
+    session.refresh(service)
+    return service
+
+
+def test_get_all_treatment_plans_returns_data(client, session):
+    service = _create_service(session)
+
+    tp_category = Category(
+        name="Liệu trình",
+        description="Danh mục liệu trình",
+        category_type=CategoryTypeEnum.treatment_plan,
+    )
+    session.add(tp_category)
+    session.commit()
+    session.refresh(tp_category)
+
+    treatment_plan = TreatmentPlan(
+        name="Liệu trình chăm sóc da",
+        description="Quy trình chăm sóc da toàn diện",
+        price=1500000,
+        total_sessions=5,
+        category_id=tp_category.id,
+    )
+    session.add(treatment_plan)
+    session.commit()
+    session.refresh(treatment_plan)
+
+    step = TreatmentPlanStep(
+        treatment_plan_id=treatment_plan.id,
+        service_id=service.id,
+        step_number=1,
+        description="Bước đầu tiên",
+    )
+    session.add(step)
+
+    image = Image(
+        url="https://example.com/treatment.jpg",
+        alt_text="Liệu trình",
+        is_primary=True,
+        treatment_plan_id=treatment_plan.id,
+    )
+    session.add(image)
+    session.commit()
+
+    response = client.get("/treatment-plans")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    plan = data[0]
+    assert plan["id"] == str(treatment_plan.id)
+    assert plan["category"]["id"] == str(tp_category.id)
+    assert plan["images"][0]["url"] == image.url
+    assert plan["steps"][0]["service"]["id"] == str(service.id)
+
+
+def test_get_treatment_plan_not_found_returns_404(client):
+    response = client.get(f"/treatment-plans/{uuid.uuid4()}")
+    assert response.status_code == 404
+    assert "TreatmentPlan" in response.json()["detail"]


### PR DESCRIPTION
## Summary
- add service modules for products and treatment plans with validation and relationship handling
- refactor product and treatment plan APIs to inject database sessions and delegate CRUD operations to the new services
- add SQLite-backed integration tests and dependency overrides to verify successful and error responses for the endpoints

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68e20fb5364483288eb70e158db809e6