### PR TITLE
fix: avoid shared defaults in service schema

### DIFF
--- a/back-end/app/schemas/services_schema.py
+++ b/back-end/app/schemas/services_schema.py
@@ -1,7 +1,8 @@
 # app/schemas/services_schema.py
-from typing import Optional, List
-from sqlmodel import SQLModel, Field
 import uuid
+from typing import Optional
+
+from sqlmodel import Field, SQLModel
 
 from app.schemas.catalog_schema import CategoryPublic, ImagePublic
 
@@ -18,7 +19,7 @@ class ServiceBase(SQLModel):
     contraindications: str | None
 
     # THAY ĐỔI: Chấp nhận một danh sách các ID danh mục
-    category_ids: List[uuid.UUID] = Field(description="Danh sách ID của các danh mục")
+    category_ids: list[uuid.UUID] = Field(description="Danh sách ID của các danh mục")
 
 
 class ServiceCreate(ServiceBase):
@@ -34,7 +35,7 @@ class ServiceUpdate(SQLModel):
     aftercare_instructions: str | None = Field(default=None)
     contraindications: str | None = Field(default=None)
     # THAY ĐỔI: Cho phép cập nhật danh sách danh mục
-    category_ids: List[uuid.UUID] | None = Field(default=None)
+    category_ids: list[uuid.UUID] | None = Field(default=None)
 
 
 class ServicePublic(ServiceBase):
@@ -42,9 +43,11 @@ class ServicePublic(ServiceBase):
 
 
 class ServicePublicWithDetails(ServicePublic):
+    model_config = {"from_attributes": True}
+
     # THAY ĐỔI: Hiển thị danh sách các danh mục
-    categories: List[CategoryPublic] = []
-    images: List[ImagePublic] = []
+    categories: list[CategoryPublic] = Field(default_factory=list)
+    images: list[ImagePublic] = Field(default_factory=list)
 
 
 # Cần forward reference cho treatment plan schema

--- a/back-end/tests/test_schema_list_defaults.py
+++ b/back-end/tests/test_schema_list_defaults.py
@@ -144,3 +144,17 @@ def test_schema_list_defaults_are_independent(model_cls, kwargs_factory, list_fi
         assert list_a == []
         assert list_b == []
         assert list_a is not list_b
+
+
+def test_service_public_with_details_lists_are_independent():
+    kwargs = make_service_kwargs()
+    service_a = ServicePublicWithDetails(**kwargs)
+    service_b = ServicePublicWithDetails(**kwargs)
+
+    assert service_a.categories == []
+    assert service_b.categories == []
+    assert service_a.categories is not service_b.categories
+
+    assert service_a.images == []
+    assert service_b.images == []
+    assert service_a.images is not service_b.images


### PR DESCRIPTION
## Summary
- replace mutable list defaults in `ServicePublicWithDetails` with `Field(default_factory=list)` and enable ORM compatibility
- update related type hints to use builtin collection types
- extend schema default tests to cover independent list initialization for the service schema

## Testing
- pytest tests/test_schema_list_defaults.py

------
https://chatgpt.com/codex/tasks/task_e_68e21ddfc55c8328afbaebbece9fdc83