### PR TITLE
Refine primary image handling across catalog entities

### DIFF
--- a/back-end/app/api/images_api.py
+++ b/back-end/app/api/images_api.py
@@ -1,0 +1,53 @@
+"""API quản lý hình ảnh dùng chung."""
+
+import uuid
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, File, Form, UploadFile, status
+from sqlmodel import Session
+
+from app.core.dependencies import get_db_session
+from app.schemas.catalog_schema import ImagePublic
+from app.services import images_service
+
+router = APIRouter()
+
+
+@router.post("", response_model=ImagePublic, status_code=status.HTTP_201_CREATED)
+async def upload_image(
+    *,
+    session: Session = Depends(get_db_session),
+    file: UploadFile = File(...),
+    alt_text: Optional[str] = Form(None),
+    product_id: Optional[uuid.UUID] = Form(None),
+    service_id: Optional[uuid.UUID] = Form(None),
+    treatment_plan_id: Optional[uuid.UUID] = Form(None),
+):
+    """Tải ảnh lên kho lưu trữ và lưu metadata."""
+
+    return await images_service.create_image(
+        db=session,
+        file=file,
+        alt_text=alt_text,
+        product_id=product_id,
+        service_id=service_id,
+        treatment_plan_id=treatment_plan_id,
+    )
+
+
+@router.get("", response_model=List[ImagePublic])
+def list_images(
+    *,
+    session: Session = Depends(get_db_session),
+    product_id: Optional[uuid.UUID] = None,
+    service_id: Optional[uuid.UUID] = None,
+    treatment_plan_id: Optional[uuid.UUID] = None,
+):
+    """Trả về danh sách hình ảnh, hỗ trợ lọc theo đối tượng sở hữu."""
+
+    return images_service.list_images(
+        db=session,
+        product_id=product_id,
+        service_id=service_id,
+        treatment_plan_id=treatment_plan_id,
+    )

--- a/back-end/app/api/products_api.py
+++ b/back-end/app/api/products_api.py
@@ -37,6 +37,7 @@ async def create_product(
     category_ids: List[uuid.UUID] = Form(...),
     existing_image_ids: Optional[List[uuid.UUID]] = Form(None),
     images: List[UploadFile] = File([]),
+    primary_image_id: Optional[uuid.UUID] = Form(None),
 ):
     """Tạo mới một sản phẩm."""
 
@@ -52,6 +53,7 @@ async def create_product(
         conversion_rate=conversion_rate,
         category_ids=category_ids,
         existing_image_ids=existing_image_ids or [],
+        primary_image_id=primary_image_id,
     )
 
     return await products_service.create_product(
@@ -59,6 +61,7 @@ async def create_product(
         product_in=product_in,
         new_images=images,
         existing_image_ids=product_in.existing_image_ids,
+        primary_image_id=product_in.primary_image_id,
     )
 
 
@@ -97,6 +100,7 @@ async def update_product(
     category_ids: Optional[List[uuid.UUID]] = Form(None),
     existing_image_ids: Optional[List[uuid.UUID]] = Form(None),
     images: List[UploadFile] = File([]),
+    primary_image_id: Optional[uuid.UUID] = Form(None),
 ):
     """Cập nhật thông tin một sản phẩm."""
 
@@ -121,12 +125,16 @@ async def update_product(
     if category_ids is not None:
         product_in.category_ids = category_ids
 
+    if primary_image_id is not None:
+        product_in.primary_image_id = primary_image_id
+
     return await products_service.update_product(
         db=session,
         db_product=db_product,
         product_in=product_in,
         new_images=images,
         existing_image_ids=existing_image_ids,
+        primary_image_id=primary_image_id,
     )
 
 

--- a/back-end/app/api/routers.py
+++ b/back-end/app/api/routers.py
@@ -10,6 +10,7 @@ from app.api import (
     products_api,
     treatment_plan_api,
     catalog_api,
+    images_api,
 )
 
 router = APIRouter()
@@ -34,3 +35,4 @@ router.include_router(products_api.router, prefix="/products", tags=["Products"]
 router.include_router(
     treatment_plan_api.router, prefix="/treatment-plans", tags=["Treatment Plans"]
 )
+router.include_router(images_api.router, prefix="/images", tags=["Images"])

--- a/back-end/app/api/test_api.py
+++ b/back-end/app/api/test_api.py
@@ -3,8 +3,6 @@ from fastapi import APIRouter
 
 
 router = APIRouter()
-
-
 @router.get("/test")
-async def test_endpoint():
+async def get_test_endpoint():
     return {"message": "Test endpoint is working!"}

--- a/back-end/app/api/treatment_plan_api.py
+++ b/back-end/app/api/treatment_plan_api.py
@@ -22,14 +22,14 @@ router = APIRouter()
     response_model=TreatmentPlanPublicWithDetails,
     status_code=status.HTTP_201_CREATED,
 )
-def create_treatment_plan(
+async def create_treatment_plan(
     *,
     session: Session = Depends(get_db_session),
     treatment_plan_in: TreatmentPlanCreate,
 ):
     """Tạo mới một liệu trình cùng các bước."""
 
-    return treatment_plans_service.create_treatment_plan(
+    return await treatment_plans_service.create_treatment_plan(
         db=session, treatment_plan_in=treatment_plan_in
     )
 
@@ -57,7 +57,7 @@ def get_treatment_plan_by_id(
 
 
 @router.put("/{treatment_plan_id}", response_model=TreatmentPlanPublicWithDetails)
-def update_treatment_plan(
+async def update_treatment_plan(
     *,
     treatment_plan_id: uuid.UUID,
     treatment_plan_in: TreatmentPlanUpdate,
@@ -68,7 +68,7 @@ def update_treatment_plan(
     db_treatment_plan = treatment_plans_service.get_treatment_plan_by_id(
         db=session, treatment_plan_id=treatment_plan_id
     )
-    return treatment_plans_service.update_treatment_plan(
+    return await treatment_plans_service.update_treatment_plan(
         db=session,
         db_treatment_plan=db_treatment_plan,
         treatment_plan_in=treatment_plan_in,

--- a/back-end/app/models/catalog_model.py
+++ b/back-end/app/models/catalog_model.py
@@ -35,12 +35,21 @@ class Image(BaseUUIDModel, table=True):
     __tablename__ = "image"
     url: str = Field(nullable=False)
     alt_text: Optional[str] = Field(default=None)
-    is_primary: bool = Field(default=False)
     service_id: Optional[uuid.UUID] = Field(default=None, foreign_key="service.id")
     product_id: Optional[uuid.UUID] = Field(default=None, foreign_key="product.id")
     treatment_plan_id: Optional[uuid.UUID] = Field(
         default=None, foreign_key="treatment_plan.id"
     )
-    service: Optional["Service"] = Relationship(back_populates="images")
-    product: Optional["Product"] = Relationship(back_populates="images")
-    treatment_plan: Optional["TreatmentPlan"] = Relationship(back_populates="images")
+    service: Optional["Service"] = Relationship(
+        back_populates="images",
+        sa_relationship_kwargs={"foreign_keys": "Image.service_id"},
+    )
+    product: Optional["Product"] = Relationship(
+        back_populates="images",
+        sa_relationship_kwargs={"foreign_keys": "Image.product_id"},
+    )
+    treatment_plan: Optional["TreatmentPlan"] = Relationship(
+        back_populates="images",
+        sa_relationship_kwargs={"foreign_keys": "Image.treatment_plan_id"},
+    )
+

--- a/back-end/app/models/products_model.py
+++ b/back-end/app/models/products_model.py
@@ -1,4 +1,5 @@
 # app/models/products_model.py
+import uuid
 from typing import List, Optional, TYPE_CHECKING
 from sqlmodel import Field, Relationship
 from app.models.base_model import BaseUUIDModel
@@ -23,4 +24,16 @@ class Product(BaseUUIDModel, table=True):
     categories: List["Category"] = Relationship(
         back_populates="products", link_model=ProductCategoryLink
     )
-    images: List["Image"] = Relationship(back_populates="product")
+    images: List["Image"] = Relationship(
+        back_populates="product",
+        sa_relationship_kwargs={"foreign_keys": "Image.product_id"},
+    )
+    primary_image_id: Optional[uuid.UUID] = Field(
+        default=None, foreign_key="image.id", nullable=True
+    )
+    primary_image: Optional["Image"] = Relationship(
+        sa_relationship_kwargs={
+            "lazy": "selectin",
+            "foreign_keys": "Product.primary_image_id",
+        }
+    )

--- a/back-end/app/models/services_model.py
+++ b/back-end/app/models/services_model.py
@@ -38,7 +38,19 @@ class Service(BaseUUIDModel, table=True):
         back_populates="services", link_model=ServiceCategoryLink
     )
 
-    images: List["Image"] = Relationship(back_populates="service")
+    images: List["Image"] = Relationship(
+        back_populates="service",
+        sa_relationship_kwargs={"foreign_keys": "Image.service_id"},
+    )
+    primary_image_id: Optional[uuid.UUID] = Field(
+        default=None, foreign_key="image.id", nullable=True
+    )
+    primary_image: Optional["Image"] = Relationship(
+        sa_relationship_kwargs={
+            "lazy": "selectin",
+            "foreign_keys": "Service.primary_image_id",
+        }
+    )
 
     @property
     def category_ids(self) -> List[uuid.UUID]:

--- a/back-end/app/models/treatment_plans_model.py
+++ b/back-end/app/models/treatment_plans_model.py
@@ -30,5 +30,17 @@ class TreatmentPlan(BaseUUIDModel, table=True):
 
     category_id: uuid.UUID = Field(foreign_key="category.id")
     category: "Category" = Relationship(back_populates="treatment_plans")
-    images: List["Image"] = Relationship(back_populates="treatment_plan")
+    images: List["Image"] = Relationship(
+        back_populates="treatment_plan",
+        sa_relationship_kwargs={"foreign_keys": "Image.treatment_plan_id"},
+    )
+    primary_image_id: Optional[uuid.UUID] = Field(
+        default=None, foreign_key="image.id", nullable=True
+    )
+    primary_image: Optional["Image"] = Relationship(
+        sa_relationship_kwargs={
+            "lazy": "selectin",
+            "foreign_keys": "TreatmentPlan.primary_image_id",
+        }
+    )
     steps: List["TreatmentPlanStep"] = Relationship(back_populates="treatment_plan")

--- a/back-end/app/schemas/catalog_schema.py
+++ b/back-end/app/schemas/catalog_schema.py
@@ -1,8 +1,9 @@
 # app/schemas/catalog_schema.py
 import uuid
-from typing import Any, Optional
-from sqlmodel import SQLModel, Field
 from enum import Enum
+from typing import Any, Optional
+
+from sqlmodel import Field, SQLModel
 
 
 # =================================================================
@@ -11,11 +12,11 @@ from enum import Enum
 class ImageBase(SQLModel):
     url: str
     alt_text: str | None = Field(default=None)
-    is_primary: bool = Field(default=False)
 
 
 class ImagePublic(ImageBase):
     id: uuid.UUID
+    model_config = {"from_attributes": True}
 
 
 # =================================================================

--- a/back-end/app/schemas/products_schema.py
+++ b/back-end/app/schemas/products_schema.py
@@ -31,6 +31,10 @@ class ProductCreate(ProductBase):
         default_factory=list,
         description="Danh sách ID hình ảnh cần liên kết với sản phẩm",
     )
+    primary_image_id: uuid.UUID | None = Field(
+        default=None,
+        description="ID của hình ảnh sẽ được đặt làm ảnh chính",
+    )
     new_images: List[UploadFile] = Field(default_factory=list, exclude=True)
 
 
@@ -48,6 +52,10 @@ class ProductUpdate(SQLModel):
     # Thêm các trường khác nếu muốn cho phép cập nhật
     existing_image_ids: Optional[List[uuid.UUID]] = Field(default=None, exclude=True)
     new_images: Optional[List[UploadFile]] = Field(default=None, exclude=True)
+    primary_image_id: uuid.UUID | None = Field(
+        default=None,
+        description="ID của hình ảnh sẽ được đặt làm ảnh chính",
+    )
 
     model_config = {"arbitrary_types_allowed": True}
 
@@ -61,3 +69,4 @@ class ProductPublicWithDetails(ProductPublic):
 
     categories: list[CategoryPublic] = Field(default_factory=list)
     images: list[ImagePublic] = Field(default_factory=list)
+    primary_image_id: uuid.UUID | None = None

--- a/back-end/app/schemas/services_schema.py
+++ b/back-end/app/schemas/services_schema.py
@@ -2,6 +2,7 @@
 import uuid
 from typing import Optional
 
+from fastapi import UploadFile
 from sqlmodel import Field, SQLModel
 
 from app.schemas.catalog_schema import CategoryPublic, ImagePublic
@@ -23,7 +24,17 @@ class ServiceBase(SQLModel):
 
 
 class ServiceCreate(ServiceBase):
-    pass
+    model_config = {"arbitrary_types_allowed": True}
+
+    existing_image_ids: list[uuid.UUID] = Field(
+        default_factory=list,
+        description="Danh sách ID hình ảnh sẽ được gán cho dịch vụ",
+    )
+    primary_image_id: uuid.UUID | None = Field(
+        default=None,
+        description="ID hình ảnh sẽ được đặt làm ảnh chính",
+    )
+    new_images: list[UploadFile] = Field(default_factory=list, exclude=True)
 
 
 class ServiceUpdate(SQLModel):
@@ -36,6 +47,9 @@ class ServiceUpdate(SQLModel):
     contraindications: str | None = Field(default=None)
     # THAY ĐỔI: Cho phép cập nhật danh sách danh mục
     category_ids: list[uuid.UUID] | None = Field(default=None)
+    existing_image_ids: list[uuid.UUID] | None = Field(default=None, exclude=True)
+    primary_image_id: uuid.UUID | None = Field(default=None)
+    new_images: list[UploadFile] | None = Field(default=None, exclude=True)
 
 
 class ServicePublic(ServiceBase):
@@ -48,6 +62,7 @@ class ServicePublicWithDetails(ServicePublic):
     # THAY ĐỔI: Hiển thị danh sách các danh mục
     categories: list[CategoryPublic] = Field(default_factory=list)
     images: list[ImagePublic] = Field(default_factory=list)
+    primary_image_id: uuid.UUID | None = None
 
 
 # Cần forward reference cho treatment plan schema

--- a/back-end/app/schemas/treatment_plans_schema.py
+++ b/back-end/app/schemas/treatment_plans_schema.py
@@ -1,7 +1,9 @@
 # app/schemas/treatment_plans_schema.py
 import uuid
 from typing import Optional
-from sqlmodel import SQLModel, Field
+
+from sqlmodel import Field, SQLModel
+
 from app.schemas.catalog_schema import CategoryPublic, ImagePublic
 
 # Cần import ServicePublic để hiển thị trong step
@@ -29,6 +31,14 @@ class TreatmentPlanBase(SQLModel):
 
 class TreatmentPlanCreate(TreatmentPlanBase):
     steps: list[TreatmentPlanStepBase] = Field(default_factory=list)
+    existing_image_ids: list[uuid.UUID] = Field(
+        default_factory=list,
+        description="Danh sách ID hình ảnh cần gán cho liệu trình",
+    )
+    primary_image_id: uuid.UUID | None = Field(
+        default=None,
+        description="ID hình ảnh sẽ được đặt làm ảnh chính",
+    )
 
 
 class TreatmentPlanUpdate(SQLModel):
@@ -37,6 +47,8 @@ class TreatmentPlanUpdate(SQLModel):
     price: Optional[float] = Field(default=None, gt=0)
     total_sessions: Optional[int] = Field(default=None, gt=0)
     category_id: Optional[uuid.UUID] = None
+    existing_image_ids: list[uuid.UUID] | None = Field(default=None)
+    primary_image_id: uuid.UUID | None = Field(default=None)
 
 
 class TreatmentPlanPublic(TreatmentPlanBase):
@@ -49,3 +61,4 @@ class TreatmentPlanPublicWithDetails(TreatmentPlanPublic):
     category: CategoryPublic
     images: list[ImagePublic] = Field(default_factory=list)
     steps: list[TreatmentPlanStepPublic] = Field(default_factory=list)
+    primary_image_id: uuid.UUID | None = None

--- a/back-end/app/services/images_service.py
+++ b/back-end/app/services/images_service.py
@@ -1,0 +1,223 @@
+"""Các hàm tiện ích dùng chung cho xử lý hình ảnh."""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Literal, Optional
+
+from fastapi import HTTPException, UploadFile, status
+from sqlmodel import Session, select
+
+from app.core import supabase_client
+from app.models.catalog_model import Image
+
+OwnerType = Literal["product", "service", "treatment_plan"]
+
+
+@dataclass(frozen=True)
+class _ImageOwnerConfig:
+    target_field: str
+    other_fields: tuple[str, ...]
+
+
+_OWNER_CONFIG: Dict[OwnerType, _ImageOwnerConfig] = {
+    "product": _ImageOwnerConfig(
+        target_field="product_id",
+        other_fields=("service_id", "treatment_plan_id"),
+    ),
+    "service": _ImageOwnerConfig(
+        target_field="service_id",
+        other_fields=("product_id", "treatment_plan_id"),
+    ),
+    "treatment_plan": _ImageOwnerConfig(
+        target_field="treatment_plan_id",
+        other_fields=("product_id", "service_id"),
+    ),
+}
+
+
+def _ensure_single_relation(
+    *, product_id: Optional[uuid.UUID], service_id: Optional[uuid.UUID], treatment_plan_id: Optional[uuid.UUID]
+) -> None:
+    provided = [value for value in (product_id, service_id, treatment_plan_id) if value is not None]
+    if len(provided) > 1:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Mỗi hình ảnh chỉ được gắn với duy nhất một loại đối tượng (sản phẩm, dịch vụ hoặc liệu trình).",
+        )
+
+
+def _get_image_by_id(db: Session, image_id: uuid.UUID) -> Image:
+    image = db.exec(
+        select(Image).where(Image.id == image_id, Image.is_deleted == False)  # noqa: E712
+    ).first()
+    if not image:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Không tìm thấy hình ảnh với ID {image_id}.",
+        )
+    return image
+
+
+async def create_image(
+    db: Session,
+    *,
+    file: UploadFile,
+    alt_text: Optional[str] = None,
+    product_id: Optional[uuid.UUID] = None,
+    service_id: Optional[uuid.UUID] = None,
+    treatment_plan_id: Optional[uuid.UUID] = None,
+) -> Image:
+    """Tải ảnh lên dịch vụ lưu trữ và lưu metadata vào cơ sở dữ liệu."""
+
+    _ensure_single_relation(
+        product_id=product_id, service_id=service_id, treatment_plan_id=treatment_plan_id
+    )
+
+    if not getattr(file, "filename", None):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Tập tin hình ảnh không hợp lệ.",
+        )
+
+    image_url = await supabase_client.upload_image(file=file)
+    if not image_url:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Không thể tải hình ảnh lên kho lưu trữ.",
+        )
+
+    db_image = Image(
+        url=image_url,
+        alt_text=alt_text,
+        product_id=product_id,
+        service_id=service_id,
+        treatment_plan_id=treatment_plan_id,
+    )
+    db.add(db_image)
+    db.commit()
+    db.refresh(db_image)
+    return db_image
+
+
+def list_images(
+    db: Session,
+    *,
+    product_id: Optional[uuid.UUID] = None,
+    service_id: Optional[uuid.UUID] = None,
+    treatment_plan_id: Optional[uuid.UUID] = None,
+) -> List[Image]:
+    """Lấy danh sách hình ảnh, có thể lọc theo đối tượng sở hữu."""
+
+    _ensure_single_relation(
+        product_id=product_id, service_id=service_id, treatment_plan_id=treatment_plan_id
+    )
+
+    statement = select(Image).where(Image.is_deleted == False)  # noqa: E712
+
+    if product_id is not None:
+        statement = statement.where(Image.product_id == product_id)
+    if service_id is not None:
+        statement = statement.where(Image.service_id == service_id)
+    if treatment_plan_id is not None:
+        statement = statement.where(Image.treatment_plan_id == treatment_plan_id)
+
+    return db.exec(statement).all()
+
+
+def _apply_owner(image: Image, owner: OwnerType, entity_id: Optional[uuid.UUID]) -> None:
+    config = _OWNER_CONFIG[owner]
+    setattr(image, config.target_field, entity_id)
+    for field in config.other_fields:
+        setattr(image, field, None)
+
+
+async def sync_entity_images(
+    db: Session,
+    *,
+    entity,
+    owner: OwnerType,
+    new_images: Optional[List[UploadFile]] = None,
+    existing_image_ids: Optional[Iterable[uuid.UUID]] = None,
+    primary_image_id: Optional[uuid.UUID] = None,
+    alt_text: Optional[str] = None,
+) -> List[Image]:
+    """Đồng bộ danh sách hình ảnh cho một đối tượng cụ thể."""
+
+    if owner not in _OWNER_CONFIG:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Loại đối tượng hình ảnh không được hỗ trợ.",
+        )
+
+    current_images = [image for image in getattr(entity, "images", []) if not image.is_deleted]
+
+    if existing_image_ids is None:
+        ordered_existing_ids: List[uuid.UUID] = [image.id for image in current_images]
+    else:
+        ordered_existing_ids = list(dict.fromkeys(existing_image_ids))
+
+    keep_ids = set(ordered_existing_ids)
+    for image in current_images:
+        if image.id not in keep_ids:
+            _apply_owner(image, owner, None)
+            db.add(image)
+
+    ordered_images: List[Image] = []
+    previous_primary_id: Optional[uuid.UUID] = getattr(entity, "primary_image_id", None)
+
+    for image_id in ordered_existing_ids:
+        image = _get_image_by_id(db, image_id)
+        config = _OWNER_CONFIG[owner]
+        current_owner_id = getattr(image, config.target_field)
+        if current_owner_id not in (None, getattr(entity, "id", None)):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Hình ảnh {image_id} đang được sử dụng bởi {owner} khác.",
+            )
+        _apply_owner(image, owner, getattr(entity, "id", None))
+        db.add(image)
+        ordered_images.append(image)
+
+    for image_file in new_images or []:
+        if not getattr(image_file, "filename", None):
+            continue
+        image_url = await supabase_client.upload_image(file=image_file)
+        if not image_url:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Không thể tải hình ảnh lên kho lưu trữ.",
+            )
+        db_image = Image(
+            url=image_url,
+            alt_text=alt_text,
+        )
+        _apply_owner(db_image, owner, getattr(entity, "id", None))
+        db.add(db_image)
+        db.flush()
+        ordered_images.append(db_image)
+
+    resolved_primary_id: Optional[uuid.UUID] = None
+    ordered_ids = [image.id for image in ordered_images]
+
+    if primary_image_id is not None:
+        if primary_image_id not in ordered_ids:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Ảnh chính được chọn không thuộc danh sách hình ảnh hiện tại.",
+            )
+        resolved_primary_id = primary_image_id
+    elif previous_primary_id in ordered_ids:
+        resolved_primary_id = previous_primary_id
+    elif ordered_ids:
+        resolved_primary_id = ordered_ids[0]
+
+    if hasattr(entity, "primary_image_id"):
+        entity.primary_image_id = resolved_primary_id
+        db.add(entity)
+
+    if hasattr(entity, "images"):
+        entity.images = ordered_images
+
+    return ordered_images

--- a/back-end/app/services/services_service.py
+++ b/back-end/app/services/services_service.py
@@ -1,21 +1,34 @@
 # app/services/services_service.py
 import uuid
 from typing import List, Optional
-from fastapi import HTTPException, status
+
+from fastapi import HTTPException, UploadFile, status
+from sqlalchemy.orm import selectinload
 from sqlmodel import Session, select
 
+from app.models.catalog_model import Category
 from app.models.services_model import Service
-from app.models.catalog_model import Image, Category
-from app.schemas.services_schema import ServiceCreate, ServiceUpdate
 from app.schemas.catalog_schema import CategoryTypeEnum
-from app.core import supabase_client
-from fastapi import UploadFile
-from app.utils.common import get_object_or_404
+from app.schemas.services_schema import ServiceCreate, ServiceUpdate
 from app.services import catalog_service
+from app.services.images_service import sync_entity_images
+
+
+def _filter_soft_deleted_relationships(service: Service) -> Service:
+    service.images = [image for image in service.images if not image.is_deleted]
+    service.categories = [
+        category for category in service.categories if not category.is_deleted
+    ]
+    valid_image_ids = {image.id for image in service.images}
+    if service.primary_image_id not in valid_image_ids:
+        service.primary_image_id = None
+    return service
 
 
 async def create_service(
-    db: Session, service_in: ServiceCreate, images: List[UploadFile]
+    db: Session,
+    service_in: ServiceCreate,
+    images: Optional[List[UploadFile]] = None,
 ) -> Service:
     """Tạo mới một dịch vụ, liên kết với nhiều danh mục và tải hình ảnh."""
     # 1. Kiểm tra sự tồn tại của các danh mục
@@ -48,7 +61,14 @@ async def create_service(
         )
 
     # 3. Tạo đối tượng dịch vụ
-    service_data = service_in.model_dump(exclude={"category_ids"})
+    service_data = service_in.model_dump(
+        exclude={
+            "category_ids",
+            "existing_image_ids",
+            "new_images",
+            "primary_image_id",
+        }
+    )
     db_service = Service(**service_data)
 
     # 4. Gán danh sách các danh mục đã được xác thực
@@ -58,32 +78,36 @@ async def create_service(
     db.commit()
     db.refresh(db_service)
 
-    # 5. Tải hình ảnh (logic không đổi)
-    if images:
-        is_first_image = True
-        for image_file in images:
-            if image_file.filename:
-                image_url = await supabase_client.upload_image(file=image_file)
-                if image_url:
-                    db_image = Image(
-                        url=image_url,
-                        alt_text=db_service.name,
-                        service_id=db_service.id,
-                        is_primary=is_first_image,
-                    )
-                    db.add(db_image)
-                    is_first_image = False
-        db.commit()
-        db.refresh(db_service)
+    await sync_entity_images(
+        db,
+        entity=db_service,
+        owner="service",
+        new_images=images,
+        existing_image_ids=service_in.existing_image_ids,
+        primary_image_id=service_in.primary_image_id,
+        alt_text=db_service.name,
+    )
 
-    return db_service
+    db.commit()
+    db.refresh(db_service)
+
+    return get_service_by_id(db, db_service.id)
 
 
-def update_service(
-    db: Session, db_service: Service, service_in: ServiceUpdate
+async def update_service(
+    db: Session,
+    db_service: Service,
+    service_in: ServiceUpdate,
+    *,
+    new_images: Optional[List[UploadFile]] = None,
+    existing_image_ids: Optional[List[uuid.UUID]] = None,
+    primary_image_id: Optional[uuid.UUID] = None,
 ) -> Service:
     """Cập nhật thông tin dịch vụ, bao gồm cả danh sách danh mục."""
     service_data = service_in.model_dump(exclude_unset=True)
+    service_data.pop("existing_image_ids", None)
+    service_data.pop("new_images", None)
+    service_data.pop("primary_image_id", None)
 
     # Cập nhật danh sách danh mục nếu có
     if "category_ids" in service_data:
@@ -104,23 +128,68 @@ def update_service(
         setattr(db_service, key, value)
 
     db.add(db_service)
+    db.flush()
+
+    await sync_entity_images(
+        db,
+        entity=db_service,
+        owner="service",
+        new_images=new_images,
+        existing_image_ids=(
+            existing_image_ids
+            if existing_image_ids is not None
+            else service_in.existing_image_ids
+        ),
+        primary_image_id=(
+            primary_image_id
+            if primary_image_id is not None
+            else service_in.primary_image_id
+        ),
+        alt_text=db_service.name,
+    )
+
     db.commit()
     db.refresh(db_service)
-    return db_service
+    return get_service_by_id(db, db_service.id)
 
 
 # ... (các hàm get_all_services, get_service_by_id, delete_service giữ nguyên)
 def get_all_services(db: Session, skip: int = 0, limit: int = 100) -> List[Service]:
     """Lấy danh sách tất cả dịch vụ CHƯA BỊ XÓA."""
-    services = db.exec(
-        select(Service).where(Service.is_deleted == False).offset(skip).limit(limit)
-    ).all()
-    return services
+    statement = (
+        select(Service)
+        .options(
+            selectinload(Service.categories),
+            selectinload(Service.images),
+            selectinload(Service.primary_image),
+        )
+        .where(Service.is_deleted == False)
+        .offset(skip)
+        .limit(limit)
+    )
+    services = db.exec(statement).unique().all()
+    return [_filter_soft_deleted_relationships(service) for service in services]
 
 
 def get_service_by_id(db: Session, service_id: uuid.UUID) -> Service:
     """Lấy dịch vụ bằng ID, đảm bảo nó tồn tại và chưa bị xóa."""
-    return get_object_or_404(db, model=Service, obj_id=service_id)
+
+    statement = (
+        select(Service)
+        .options(
+            selectinload(Service.categories),
+            selectinload(Service.images),
+            selectinload(Service.primary_image),
+        )
+        .where(Service.id == service_id, Service.is_deleted == False)
+    )
+    service = db.exec(statement).unique().first()
+    if not service:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Service với ID {service_id} không được tìm thấy.",
+        )
+    return _filter_soft_deleted_relationships(service)
 
 
 def delete_service(db: Session, db_service: Service) -> Service:

--- a/back-end/tests/test_product_images.py
+++ b/back-end/tests/test_product_images.py
@@ -1,5 +1,4 @@
 import uuid
-
 from sqlmodel import select
 
 from app.models.catalog_model import Category, Image
@@ -30,7 +29,6 @@ def test_create_product_with_new_and_existing_images(client, session, monkeypatc
     reusable_image = Image(
         url="https://cdn.example.com/reuse.jpg",
         alt_text="Hình ảnh dùng lại",
-        is_primary=False,
     )
     session.add(reusable_image)
     session.commit()
@@ -73,4 +71,4 @@ def test_create_product_with_new_and_existing_images(client, session, monkeypatc
     ).first()
     assert new_image is not None
     assert new_image.product_id == uuid.UUID(payload["id"])
-    assert any(image["is_primary"] for image in payload["images"])
+    assert payload["primary_image_id"] == str(reusable_image.id)

--- a/back-end/tests/test_products_api.py
+++ b/back-end/tests/test_products_api.py
@@ -32,11 +32,16 @@ def test_get_all_products_returns_data(client, session):
     image = Image(
         url="https://example.com/image.jpg",
         alt_text="Sản phẩm",
-        is_primary=True,
         product_id=product.id,
     )
     session.add(image)
     session.commit()
+    session.refresh(image)
+
+    product.primary_image_id = image.id
+    session.add(product)
+    session.commit()
+    session.refresh(product)
 
     response = client.get("/products")
     assert response.status_code == 200
@@ -46,6 +51,7 @@ def test_get_all_products_returns_data(client, session):
     assert len(data[0]["categories"]) == 1
     assert data[0]["categories"][0]["id"] == str(category.id)
     assert data[0]["images"][0]["url"] == image.url
+    assert data[0]["primary_image_id"] == str(image.id)
 
 
 def test_get_product_not_found_returns_404(client):

--- a/back-end/tests/test_treatment_plans_api.py
+++ b/back-end/tests/test_treatment_plans_api.py
@@ -1,5 +1,4 @@
 import uuid
-
 from app.models.catalog_model import Category, Image
 from app.models.services_model import Service
 from app.models.treatment_plans_model import TreatmentPlan, TreatmentPlanStep
@@ -66,10 +65,14 @@ def test_get_all_treatment_plans_returns_data(client, session):
     image = Image(
         url="https://example.com/treatment.jpg",
         alt_text="Liệu trình",
-        is_primary=True,
         treatment_plan_id=treatment_plan.id,
     )
     session.add(image)
+    session.commit()
+    session.refresh(image)
+
+    treatment_plan.primary_image_id = image.id
+    session.add(treatment_plan)
     session.commit()
 
     response = client.get("/treatment-plans")
@@ -80,6 +83,7 @@ def test_get_all_treatment_plans_returns_data(client, session):
     assert plan["id"] == str(treatment_plan.id)
     assert plan["category"]["id"] == str(tp_category.id)
     assert plan["images"][0]["url"] == image.url
+    assert plan["primary_image_id"] == str(image.id)
     assert plan["steps"][0]["service"]["id"] == str(service.id)
 
 

--- a/front-end/src/app/(public)/products/[id]/page.tsx
+++ b/front-end/src/app/(public)/products/[id]/page.tsx
@@ -28,7 +28,10 @@ export default function ProductDetailPage({ params }: ProductDetailPageProps) {
     queryFn: () => getProductById(id),
   });
 
-  const primaryImageUrl = getPrimaryImageUrl(product?.images);
+  const primaryImageUrl = getPrimaryImageUrl(
+    product?.images,
+    product?.primary_image_id
+  );
 
   const [mainImage, setMainImage] = useState<string>(primaryImageUrl);
   useEffect(() => {

--- a/front-end/src/app/(public)/services/[id]/page.tsx
+++ b/front-end/src/app/(public)/services/[id]/page.tsx
@@ -30,7 +30,10 @@ export default function ServiceDetailPage({ params }: ServiceDetailPageProps) {
     queryFn: () => getServiceById(id),
   });
 
-  const primaryImageUrl = getPrimaryImageUrl(service?.images);
+  const primaryImageUrl = getPrimaryImageUrl(
+    service?.images,
+    service?.primary_image_id
+  );
 
   const [mainImage, setMainImage] = useState<string>(primaryImageUrl);
 

--- a/front-end/src/app/(public)/treatment-plans/[id]/page.tsx
+++ b/front-end/src/app/(public)/treatment-plans/[id]/page.tsx
@@ -34,7 +34,10 @@ export default function TreatmentPlanDetailPage({
   const { data: allServices = [], isLoading: isLoadingServices } =
     useServices();
 
-  const primaryImageUrl = getPrimaryImageUrl(plan?.images);
+  const primaryImageUrl = getPrimaryImageUrl(
+    plan?.images,
+    plan?.primary_image_id
+  );
 
   const [mainImage, setMainImage] = useState<string>(primaryImageUrl);
   useEffect(() => {

--- a/front-end/src/features/product/components/ProductCard.tsx
+++ b/front-end/src/features/product/components/ProductCard.tsx
@@ -11,6 +11,7 @@ interface ProductCardProps {
 export default function ProductCard({ product }: ProductCardProps) {
   const primaryImageUrl = getPrimaryImageUrl(
     product.images,
+    product.primary_image_id,
     "/images/default-product.jpg"
   );
   return (

--- a/front-end/src/features/product/components/ProductForm.tsx
+++ b/front-end/src/features/product/components/ProductForm.tsx
@@ -327,10 +327,9 @@ export default function ProductFormFields() {
               <MultiImageUploader
                 defaultValue={field.value}
                 onFilesSelect={(files: File[]) => {
-                  const newImageUrls: ImageUrl[] = files.map((file, index) => ({
+                  const newImageUrls: ImageUrl[] = files.map((file) => ({
                     id: uuidv4(),
                     url: URL.createObjectURL(file),
-                    is_primary: (field.value?.length || 0) + index === 0,
                     alt_text: file.name,
                   }));
                   field.onChange([...(field.value || []), ...newImageUrls]);

--- a/front-end/src/features/product/types.ts
+++ b/front-end/src/features/product/types.ts
@@ -8,6 +8,7 @@ export interface Product {
   price: number;
   stock: number;
   images: ImageUrl[];
+  primary_image_id?: string | null;
   is_retail: boolean;
   is_consumable: boolean;
   base_unit: string; // vd: "chai", "lọ", "hũ"

--- a/front-end/src/features/service/components/ServiceCard.tsx
+++ b/front-end/src/features/service/components/ServiceCard.tsx
@@ -11,6 +11,7 @@ interface ServiceCardProps {
 export default function ServiceCard({ service }: ServiceCardProps) {
   const primaryImageUrl = getPrimaryImageUrl(
     service.images,
+    service.primary_image_id,
     "/images/default-service.jpg"
   );
   return (

--- a/front-end/src/features/service/components/ServiceForm.tsx
+++ b/front-end/src/features/service/components/ServiceForm.tsx
@@ -260,10 +260,9 @@ export default function ServiceForm() {
               <MultiImageUploader
                 defaultValue={field.value}
                 onFilesSelect={(files: File[]) => {
-                  const newImageUrls: ImageUrl[] = files.map((file, index) => ({
+                  const newImageUrls: ImageUrl[] = files.map((file) => ({
                     id: uuidv4(),
                     url: URL.createObjectURL(file),
-                    is_primary: (field.value?.length || 0) + index === 0,
                     alt_text: file.name,
                   }));
                   field.onChange([...(field.value || []), ...newImageUrls]);

--- a/front-end/src/features/service/components/columns.tsx
+++ b/front-end/src/features/service/components/columns.tsx
@@ -82,6 +82,7 @@ export const getServiceColumns = (
     cell: ({ row }) => {
       const primaryImage = getPrimaryImageUrl(
         row.original.images,
+        row.original.primary_image_id,
         "/images/placeholder.png"
       );
       return (

--- a/front-end/src/features/service/types.ts
+++ b/front-end/src/features/service/types.ts
@@ -9,6 +9,7 @@ export interface Service {
   duration_minutes: number;
   categories: Category[];
   images: ImageUrl[];
+  primary_image_id?: string | null;
   status: "active" | "inactive";
   preparation_notes: string;
   aftercare_instructions: string;

--- a/front-end/src/features/shared/types.ts
+++ b/front-end/src/features/shared/types.ts
@@ -1,6 +1,5 @@
 export interface ImageUrl {
   id: string;
   url: string;
-  is_primary: boolean;
   alt_text?: string;
 }

--- a/front-end/src/features/treatment/components/TreatmentPlanCard.tsx
+++ b/front-end/src/features/treatment/components/TreatmentPlanCard.tsx
@@ -10,6 +10,7 @@ interface TreatmentPlanCardProps {
 export default function TreatmentPlanCard({ plan }: TreatmentPlanCardProps) {
   const primaryImageUrl = getPrimaryImageUrl(
     plan.images,
+    plan.primary_image_id,
     "/images/default-product.jpg"
   );
   return (

--- a/front-end/src/features/treatment/components/TreatmentPlanForm.tsx
+++ b/front-end/src/features/treatment/components/TreatmentPlanForm.tsx
@@ -302,10 +302,9 @@ export default function TreatmentPlanFormFields() {
               <MultiImageUploader
                 defaultValue={field.value}
                 onFilesSelect={(files: File[]) => {
-                  const newImageUrls: ImageUrl[] = files.map((file, index) => ({
+                  const newImageUrls: ImageUrl[] = files.map((file) => ({
                     id: uuidv4(),
                     url: URL.createObjectURL(file),
-                    is_primary: (field.value?.length || 0) + index === 0,
                     alt_text: file.name,
                   }));
                   field.onChange([...(field.value || []), ...newImageUrls]);

--- a/front-end/src/features/treatment/types.ts
+++ b/front-end/src/features/treatment/types.ts
@@ -15,6 +15,7 @@ export interface TreatmentPlan {
   price: number;
   total_sessions: number;
   images: ImageUrl[];
+  primary_image_id?: string | null;
   status: "active" | "inactive";
   is_deleted: boolean;
   created_at: Date;

--- a/front-end/src/lib/image-utils.ts
+++ b/front-end/src/lib/image-utils.ts
@@ -3,18 +3,27 @@ import { ImageUrl } from "@/features/shared/types";
 
 /**
  * Lấy URL của ảnh chính từ một mảng các ảnh.
- * Ưu tiên ảnh có is_primary = true, nếu không có thì lấy ảnh đầu tiên.
+ * Ưu tiên ảnh có ID trùng với primaryImageId, nếu không có thì lấy ảnh đầu tiên.
  * @param images - Mảng các đối tượng ảnh (ImageUrl)
+ * @param primaryImageId - ID của ảnh chính
  * @param placeholder - URL ảnh mặc định nếu không có ảnh nào
  * @returns URL của ảnh chính hoặc ảnh mặc định
  */
 export const getPrimaryImageUrl = (
   images: ImageUrl[] | undefined,
+  primaryImageId?: string | null,
   placeholder: string = "/images/placeholder.png"
 ): string => {
   if (!images || images.length === 0) {
     return placeholder;
   }
-  const primaryImage = images.find((img) => img.is_primary);
-  return primaryImage?.url || images[0]?.url || placeholder;
+
+  if (primaryImageId) {
+    const primaryImage = images.find((img) => img.id === primaryImageId);
+    if (primaryImage) {
+      return primaryImage.url;
+    }
+  }
+
+  return images[0]?.url || placeholder;
 };

--- a/front-end/src/lib/schemas.ts
+++ b/front-end/src/lib/schemas.ts
@@ -52,6 +52,5 @@ export type PersonFormValues = z.infer<typeof personSchema>;
 export const imageSchema = z.object({
   id: z.string(),
   url: z.string().url("URL hình ảnh không hợp lệ."),
-  is_primary: z.boolean(),
   alt_text: z.string().optional(),
 });


### PR DESCRIPTION
## Summary
- remove the `is_primary` flag from images and store primary ownership on products, services, and treatment plans
- update synchronization, service logic, and schemas/tests to enforce primary image validity after refactor
- align front-end types and helpers to rely on `primary_image_id` when selecting preview images

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e2367289688328b1801030dedc5616