### PR TITLE
Connect public pages to backend data sources

### DIFF
--- a/front-end/src/app/(public)/loading.tsx
+++ b/front-end/src/app/(public)/loading.tsx
@@ -1,0 +1,65 @@
+// src/app/(public)/loading.tsx
+import { DisplayCardSkeleton } from "@/components/common/DisplayCardSkeleton";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function PublicLoading() {
+  return (
+    <div>
+      <section className="relative flex h-[60vh] min-h-[400px] items-center justify-center bg-muted">
+        <div className="absolute inset-0 bg-muted-foreground/40" />
+        <div className="relative z-10 container mx-auto flex flex-col items-center gap-4 px-4 text-center">
+          <Skeleton className="h-12 w-3/4 max-w-2xl" />
+          <Skeleton className="h-4 w-full max-w-3xl" />
+          <Skeleton className="h-4 w-2/3 max-w-xl" />
+          <Skeleton className="mt-4 h-12 w-40" />
+        </div>
+      </section>
+
+      <div className="container mx-auto px-4 py-16">
+        <Skeleton className="mx-auto mb-6 h-10 w-72" />
+        <Skeleton className="mx-auto mb-10 h-4 w-2/3 max-w-2xl" />
+        <div className="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3">
+          {Array.from({ length: 3 }).map((_, index) => (
+            <DisplayCardSkeleton key={`services-${index}`} />
+          ))}
+        </div>
+      </div>
+
+      <div className="border-b" />
+
+      <div className="container mx-auto px-4 py-16">
+        <Skeleton className="mx-auto mb-6 h-10 w-64" />
+        <Skeleton className="mx-auto mb-10 h-4 w-2/3 max-w-2xl" />
+        <div className="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3">
+          {Array.from({ length: 3 }).map((_, index) => (
+            <DisplayCardSkeleton key={`plans-${index}`} />
+          ))}
+        </div>
+      </div>
+
+      <div className="border-b" />
+
+      <div className="container mx-auto px-4 py-16">
+        <Skeleton className="mx-auto mb-6 h-10 w-64" />
+        <Skeleton className="mx-auto mb-10 h-4 w-2/3 max-w-2xl" />
+        <div className="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-4">
+          {Array.from({ length: 4 }).map((_, index) => (
+            <DisplayCardSkeleton key={`products-${index}`} />
+          ))}
+        </div>
+      </div>
+
+      <div className="border-b" />
+
+      <div className="container mx-auto px-4 py-16">
+        <Skeleton className="mx-auto mb-6 h-10 w-72" />
+        <Skeleton className="mx-auto mb-10 h-4 w-2/3 max-w-2xl" />
+        <div className="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3">
+          {Array.from({ length: 3 }).map((_, index) => (
+            <DisplayCardSkeleton key={`promotions-${index}`} />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/front-end/src/app/(public)/products/page.tsx
+++ b/front-end/src/app/(public)/products/page.tsx
@@ -5,10 +5,16 @@ import { Input } from "@/components/ui/input";
 import ProductCard from "@/features/product/components/ProductCard";
 import { useProducts } from "@/features/product/hooks/useProducts";
 import { useMemo, useState } from "react";
-import { FullPageLoader } from "@/components/ui/spinner";
+import { DisplayCardSkeleton } from "@/components/common/DisplayCardSkeleton";
+import { DataStateMessage } from "@/components/common/DataStateMessage";
 
 export default function ProductsPage() {
-  const { data: products = [], isLoading } = useProducts();
+  const {
+    data: products = [],
+    isLoading,
+    isError,
+    error,
+  } = useProducts();
   const [searchTerm, setSearchTerm] = useState("");
 
   const filteredProducts = useMemo(() => {
@@ -18,9 +24,59 @@ export default function ProductsPage() {
     );
   }, [products, searchTerm]);
 
-  if (isLoading) {
-    return <FullPageLoader text="Đang tải danh sách sản phẩm..." />;
-  }
+  const renderContent = () => {
+    if (isLoading) {
+      return (
+        <div className="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-4">
+          {Array.from({ length: 8 }).map((_, index) => (
+            <DisplayCardSkeleton key={index} />
+          ))}
+        </div>
+      );
+    }
+
+    if (isError) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : "Không thể tải danh sách sản phẩm.";
+      return (
+        <DataStateMessage
+          variant="error"
+          message="Không thể tải danh sách sản phẩm"
+          description={message}
+          className="mx-auto max-w-xl"
+        />
+      );
+    }
+
+    if (products.length === 0) {
+      return (
+        <DataStateMessage
+          message="Hiện chưa có sản phẩm nào được cập nhật."
+          className="mx-auto max-w-xl"
+        />
+      );
+    }
+
+    if (filteredProducts.length === 0) {
+      return (
+        <DataStateMessage
+          message="Không tìm thấy sản phẩm phù hợp"
+          description={`Không có sản phẩm nào khớp với từ khóa "${searchTerm}".`}
+          className="mx-auto max-w-xl"
+        />
+      );
+    }
+
+    return (
+      <div className="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-4">
+        {filteredProducts.map((product) => (
+          <ProductCard key={product.id} product={product} />
+        ))}
+      </div>
+    );
+  };
 
   return (
     <div className="container mx-auto px-4 py-8">
@@ -44,20 +100,7 @@ export default function ProductsPage() {
         />
       </div>
 
-      {filteredProducts.length > 0 ? (
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-8">
-          {filteredProducts.map((product) => (
-            <ProductCard key={product.id} product={product} />
-          ))}
-        </div>
-      ) : (
-        <div className="text-center py-16">
-          <p className="text-muted-foreground">
-            Không tìm thấy sản phẩm nào phù hợp với từ khóa &quot;{searchTerm}
-            &quot;.
-          </p>
-        </div>
-      )}
+      {renderContent()}
     </div>
   );
 }

--- a/front-end/src/app/(public)/promotions/page.tsx
+++ b/front-end/src/app/(public)/promotions/page.tsx
@@ -1,14 +1,20 @@
 // src/app/(public)/promotions/page.tsx
 "use client";
 
+import { DisplayCardSkeleton } from "@/components/common/DisplayCardSkeleton";
+import { DataStateMessage } from "@/components/common/DataStateMessage";
 import { Input } from "@/components/ui/input";
 import PromotionCard from "@/features/promotion/components/PromotionCard";
-import { usePromotions } from "@/features/promotion/hooks/usePromotions"; // Giả sử bạn đã tạo hook này
+import { usePromotions } from "@/features/promotion/hooks/usePromotions";
 import { useMemo, useState } from "react";
-import { FullPageLoader } from "@/components/ui/spinner";
 
 export default function PromotionsPage() {
-  const { data: promotions = [], isLoading } = usePromotions();
+  const {
+    data: promotions = [],
+    isLoading,
+    isError,
+    error,
+  } = usePromotions();
   const [searchTerm, setSearchTerm] = useState("");
 
   const filteredPromotions = useMemo(() => {
@@ -18,23 +24,74 @@ export default function PromotionsPage() {
     );
   }, [promotions, searchTerm]);
 
-  if (isLoading) {
-    return <FullPageLoader text="Đang tải danh sách khuyến mãi..." />;
-  }
+  const renderContent = () => {
+    if (isLoading) {
+      return (
+        <div className="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3">
+          {Array.from({ length: 6 }).map((_, index) => (
+            <DisplayCardSkeleton key={index} />
+          ))}
+        </div>
+      );
+    }
+
+    if (isError) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : "Không thể tải danh sách khuyến mãi.";
+      return (
+        <DataStateMessage
+          variant="error"
+          message="Không thể tải danh sách khuyến mãi"
+          description={message}
+          className="mx-auto max-w-xl"
+        />
+      );
+    }
+
+    if (promotions.length === 0) {
+      return (
+        <DataStateMessage
+          message="Hiện chưa có chương trình khuyến mãi nào."
+          description="Vui lòng quay lại sau để cập nhật những ưu đãi mới nhất."
+          className="mx-auto max-w-xl"
+        />
+      );
+    }
+
+    if (filteredPromotions.length === 0) {
+      return (
+        <DataStateMessage
+          message="Không tìm thấy khuyến mãi phù hợp"
+          description={`Không có ưu đãi nào khớp với từ khóa "${searchTerm}".`}
+          className="mx-auto max-w-xl"
+        />
+      );
+    }
+
+    return (
+      <div className="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3">
+        {filteredPromotions.map((promotion) => (
+          <PromotionCard key={promotion.id} promotion={promotion} />
+        ))}
+      </div>
+    );
+  };
 
   return (
     <div className="container mx-auto px-4 py-8">
-      <header className="text-center mb-8">
+      <header className="mb-8 text-center">
         <h1 className="text-4xl font-bold tracking-tight">
           Ưu Đãi & Khuyến Mãi Hấp Dẫn
         </h1>
-        <p className="text-muted-foreground mt-2 max-w-2xl mx-auto">
+        <p className="text-muted-foreground mt-2 mx-auto max-w-2xl">
           Đừng bỏ lỡ các chương trình ưu đãi đặc biệt của chúng tôi để nâng tầm
           trải nghiệm chăm sóc của bạn.
         </p>
       </header>
 
-      <div className="mb-8 max-w-md mx-auto">
+      <div className="mx-auto mb-8 max-w-md">
         <Input
           type="search"
           placeholder="Tìm kiếm khuyến mãi..."
@@ -44,20 +101,7 @@ export default function PromotionsPage() {
         />
       </div>
 
-      {filteredPromotions.length > 0 ? (
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8">
-          {filteredPromotions.map((promotion) => (
-            <PromotionCard key={promotion.id} promotion={promotion} />
-          ))}
-        </div>
-      ) : (
-        <div className="text-center py-16">
-          <p className="text-muted-foreground">
-            Không tìm thấy khuyến mãi nào phù hợp với từ khóa &quot;{searchTerm}
-            &quot;.
-          </p>
-        </div>
-      )}
+      {renderContent()}
     </div>
   );
 }

--- a/front-end/src/app/(public)/treatment-plans/loading.tsx
+++ b/front-end/src/app/(public)/treatment-plans/loading.tsx
@@ -1,0 +1,24 @@
+// src/app/(public)/treatment-plans/loading.tsx
+import { DisplayCardSkeleton } from "@/components/common/DisplayCardSkeleton";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function TreatmentPlansLoading() {
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <header className="mb-8 text-center">
+        <Skeleton className="mx-auto mb-4 h-10 w-72" />
+        <Skeleton className="mx-auto h-4 w-2/3 max-w-2xl" />
+      </header>
+
+      <div className="mx-auto mb-8 max-w-md">
+        <Skeleton className="h-10 w-full" />
+      </div>
+
+      <div className="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3">
+        {Array.from({ length: 6 }).map((_, index) => (
+          <DisplayCardSkeleton key={index} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/front-end/src/app/(public)/treatment-plans/page.tsx
+++ b/front-end/src/app/(public)/treatment-plans/page.tsx
@@ -1,35 +1,62 @@
+import { DataStateMessage } from "@/components/common/DataStateMessage";
+import { Input } from "@/components/ui/input";
 import { getTreatmentPlans } from "@/features/treatment/api/treatment.api";
 import TreatmentPlanCard from "@/features/treatment/components/TreatmentPlanCard";
-import { Input } from "@/components/ui/input";
+import type { TreatmentPlan } from "@/features/treatment/types";
 
 export default async function TreatmentPlansPage() {
-  const treatmentPlans = await getTreatmentPlans();
+  let errorMessage: string | null = null;
+  let treatmentPlans: TreatmentPlan[] = [];
+
+  try {
+    treatmentPlans = await getTreatmentPlans();
+  } catch (error) {
+    errorMessage =
+      error instanceof Error
+        ? error.message
+        : "Không thể tải danh sách liệu trình.";
+  }
 
   return (
     <div className="container mx-auto px-4 py-8">
-      <header className="text-center mb-8">
+      <header className="mb-8 text-center">
         <h1 className="text-4xl font-bold tracking-tight">
           Khám Phá Các Gói Liệu Trình
         </h1>
-        <p className="text-muted-foreground mt-2 max-w-2xl mx-auto">
+        <p className="text-muted-foreground mt-2 mx-auto max-w-2xl">
           Đầu tư vào vẻ đẹp dài lâu với các gói liệu trình chuyên sâu, được
           thiết kế để mang lại hiệu quả tối ưu.
         </p>
       </header>
 
-      <div className="mb-8 max-w-md mx-auto">
+      <div className="mx-auto mb-8 max-w-md">
         <Input
           type="search"
           placeholder="Tìm kiếm liệu trình (ví dụ: triệt lông, phục hồi da...)"
           className="w-full"
+          readOnly
         />
       </div>
 
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8">
-        {treatmentPlans.map((plan) => (
-          <TreatmentPlanCard key={plan.id} plan={plan} />
-        ))}
-      </div>
+      {errorMessage ? (
+        <DataStateMessage
+          variant="error"
+          message="Không thể tải danh sách liệu trình"
+          description={errorMessage}
+          className="mx-auto max-w-xl"
+        />
+      ) : treatmentPlans.length === 0 ? (
+        <DataStateMessage
+          message="Hiện chưa có liệu trình nào được cập nhật."
+          className="mx-auto max-w-xl"
+        />
+      ) : (
+        <div className="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3">
+          {treatmentPlans.map((plan) => (
+            <TreatmentPlanCard key={plan.id} plan={plan} />
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/front-end/src/components/common/DataStateMessage.tsx
+++ b/front-end/src/components/common/DataStateMessage.tsx
@@ -1,0 +1,50 @@
+// src/components/common/DataStateMessage.tsx
+import type { HTMLAttributes } from "react";
+
+import { cn } from "@/lib/utils";
+
+type DataStateVariant = "empty" | "error";
+
+interface DataStateMessageProps extends HTMLAttributes<HTMLDivElement> {
+  message: string;
+  description?: string;
+  variant?: DataStateVariant;
+}
+
+const variantStyles: Record<DataStateVariant, string> = {
+  empty:
+    "border border-dashed border-border/60 bg-muted/40 text-muted-foreground",
+  error:
+    "border border-destructive/40 bg-destructive/10 text-destructive",
+};
+
+const descriptionStyles: Record<DataStateVariant, string> = {
+  empty: "text-muted-foreground",
+  error: "text-destructive/80",
+};
+
+export function DataStateMessage({
+  message,
+  description,
+  variant = "empty",
+  className,
+  ...props
+}: DataStateMessageProps) {
+  return (
+    <div
+      className={cn(
+        "rounded-lg px-4 py-6 text-center",
+        variantStyles[variant],
+        className
+      )}
+      {...props}
+    >
+      <p className="text-base font-semibold">{message}</p>
+      {description ? (
+        <p className={cn("mt-2 text-sm", descriptionStyles[variant])}>
+          {description}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/front-end/src/components/common/DisplayCardSkeleton.tsx
+++ b/front-end/src/components/common/DisplayCardSkeleton.tsx
@@ -1,0 +1,31 @@
+// src/components/common/DisplayCardSkeleton.tsx
+import { Card, CardContent, CardFooter, CardHeader } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+
+interface DisplayCardSkeletonProps {
+  withDescription?: boolean;
+}
+
+export function DisplayCardSkeleton({
+  withDescription = true,
+}: DisplayCardSkeletonProps) {
+  return (
+    <Card className="flex w-full flex-col">
+      <CardHeader className="p-0">
+        <Skeleton className="h-48 w-full rounded-t-lg" />
+      </CardHeader>
+      <CardContent className="flex grow flex-col gap-3 pt-6">
+        <Skeleton className="h-6 w-3/4" />
+        {withDescription ? (
+          <>
+            <Skeleton className="h-4 w-full" />
+            <Skeleton className="h-4 w-5/6" />
+          </>
+        ) : null}
+      </CardContent>
+      <CardFooter>
+        <Skeleton className="h-6 w-full" />
+      </CardFooter>
+    </Card>
+  );
+}

--- a/front-end/src/components/ui/skeleton.tsx
+++ b/front-end/src/components/ui/skeleton.tsx
@@ -1,0 +1,18 @@
+// src/components/ui/skeleton.tsx
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+type SkeletonProps = React.HTMLAttributes<HTMLDivElement>;
+
+export function Skeleton({ className, ...props }: SkeletonProps) {
+  return (
+    <div
+      className={cn(
+        "animate-pulse rounded-md bg-muted",
+        className
+      )}
+      {...props}
+    />
+  );
+}

--- a/front-end/src/features/category/api/category.api.ts
+++ b/front-end/src/features/category/api/category.api.ts
@@ -6,7 +6,11 @@ import apiClient from "@/lib/apiClient";
  * Lấy danh sách tất cả danh mục từ server
  */
 export async function getCategories(): Promise<Category[]> {
-  return apiClient<Category[]>("/categories");
+  const categories = await apiClient<Category[]>("/categories");
+  return categories.map((category) => ({
+    ...category,
+    type: category.type ?? category.category_type,
+  }));
 }
 
 /**

--- a/front-end/src/features/category/types.ts
+++ b/front-end/src/features/category/types.ts
@@ -1,11 +1,16 @@
-export type CategoryType = "service" | "product" | "treatment";
+export type CategoryType = "service" | "product" | "treatment_plan";
 
 export interface Category {
   id: string;
   name: string;
-  description?: string;
-  type: CategoryType;
-  is_deleted: boolean;
-  created_at: Date;
-  updated_at: Date;
+  description?: string | null;
+  category_type: CategoryType;
+  /**
+   * Alias cho các đoạn code cũ vẫn đang sử dụng thuộc tính `type`.
+   * Nên ưu tiên dùng `category_type`.
+   */
+  type?: CategoryType;
+  is_deleted?: boolean;
+  created_at?: string;
+  updated_at?: string;
 }

--- a/front-end/src/features/product/api/product.api.ts
+++ b/front-end/src/features/product/api/product.api.ts
@@ -1,6 +1,7 @@
 // src/features/product/api/product.api.ts
 import { Product } from "@/features/product/types";
 import apiClient from "@/lib/apiClient";
+import { buildQueryString } from "@/lib/queryString";
 import { ProductFormValues } from "@/features/product/schemas";
 import { ImageUrl } from "@/features/shared/types";
 import { uploadFile } from "@/features/upload/upload.api";
@@ -83,8 +84,15 @@ export async function updateProduct({
 /**
  * Lấy danh sách tất cả sản phẩm
  */
-export async function getProducts(): Promise<Product[]> {
-  return apiClient<Product[]>("/products");
+export interface GetProductsParams {
+  skip?: number;
+  limit?: number;
+  search?: string;
+}
+
+export async function getProducts(params?: GetProductsParams): Promise<Product[]> {
+  const query = buildQueryString(params);
+  return apiClient<Product[]>(`/products${query}`);
 }
 
 /**

--- a/front-end/src/features/product/hooks/useProducts.ts
+++ b/front-end/src/features/product/hooks/useProducts.ts
@@ -16,7 +16,9 @@ const queryKey = ["products"];
 export const useProducts = () => {
   return useQuery<Product[]>({
     queryKey: queryKey,
-    queryFn: getProducts,
+    queryFn: () => getProducts(),
+    retry: 1,
+    staleTime: 60 * 1000,
   });
 };
 

--- a/front-end/src/features/product/types.ts
+++ b/front-end/src/features/product/types.ts
@@ -1,21 +1,21 @@
+import { Category } from "@/features/category/types";
 import { ImageUrl } from "@/features/shared/types";
 
 export interface Product {
   id: string;
   name: string;
   description: string;
-  categories: string[];
+  categories: Category[];
   price: number;
   stock: number;
   images: ImageUrl[];
   primary_image_id?: string | null;
-  is_retail: boolean;
-  is_consumable: boolean;
+  is_retail?: boolean;
+  is_consumable?: boolean;
   base_unit: string; // vd: "chai", "lọ", "hũ"
-  consumable_unit?: string; // vd: "ml", "g"
-  conversion_rate?: number; // Tỷ lệ quy đổi (vd: 500ml/chai)
-  is_deleted: boolean;
-  created_at: Date;
-  updated_at: Date;
-  status: "active" | "inactive";
+  consumable_unit?: string | null; // vd: "ml", "g"
+  conversion_rate?: number | null; // Tỷ lệ quy đổi (vd: 500ml/chai)
+  is_deleted?: boolean;
+  created_at?: string;
+  updated_at?: string;
 }

--- a/front-end/src/features/promotion/api/promotion.api.ts
+++ b/front-end/src/features/promotion/api/promotion.api.ts
@@ -1,10 +1,19 @@
 // src/features/promotion/api/promotion.api.ts
 import { Promotion } from "@/features/promotion/types";
-import apiClient from "@/lib/apiClient";
+import apiClient, { ApiError } from "@/lib/apiClient";
 
 /**
  * Lấy danh sách tất cả khuyến mãi
  */
 export async function getPromotions(): Promise<Promotion[]> {
-  return apiClient<Promotion[]>("/promotions");
+  try {
+    return await apiClient<Promotion[]>("/promotions");
+  } catch (error) {
+    if (error instanceof ApiError && (error.status === 404 || error.status === 204)) {
+      // Backend chưa hỗ trợ endpoint, trả về danh sách rỗng để UI xử lý gracefully
+      return [];
+    }
+
+    throw error;
+  }
 }

--- a/front-end/src/features/promotion/components/PromotionCard.tsx
+++ b/front-end/src/features/promotion/components/PromotionCard.tsx
@@ -9,8 +9,13 @@ interface PromotionCardProps {
 }
 
 export default function PromotionCard({ promotion }: PromotionCardProps) {
-  const formatDate = (dateString: Date) => {
-    return new Date(dateString).toLocaleDateString("vi-VN");
+  const formatDate = (dateString: string) => {
+    const date = new Date(dateString);
+    if (Number.isNaN(date.getTime())) {
+      return "Đang cập nhật";
+    }
+
+    return date.toLocaleDateString("vi-VN");
   };
 
   return (

--- a/front-end/src/features/promotion/hooks/usePromotions.ts
+++ b/front-end/src/features/promotion/hooks/usePromotions.ts
@@ -6,6 +6,8 @@ import { Promotion } from "@/features/promotion/types";
 export const usePromotions = () => {
   return useQuery<Promotion[]>({
     queryKey: ["promotions"],
-    queryFn: getPromotions,
+    queryFn: () => getPromotions(),
+    retry: 1,
+    staleTime: 60 * 1000,
   });
 };

--- a/front-end/src/features/promotion/types.ts
+++ b/front-end/src/features/promotion/types.ts
@@ -2,15 +2,15 @@ export interface Promotion {
   id: string;
   title: string;
   description: string;
-  image_url: string;
+  image_url?: string | null;
   discount_percent: number;
   applicable_service_ids?: string[];
   applicable_plan_ids?: string[];
   gift_product_ids?: string[];
-  start_date: Date;
-  end_date: Date;
-  status: "active" | "inactive" | "scheduled";
-  is_deleted: boolean;
-  created_at: Date;
-  updated_at: Date;
+  start_date: string;
+  end_date: string;
+  status?: "active" | "inactive" | "scheduled";
+  is_deleted?: boolean;
+  created_at?: string;
+  updated_at?: string;
 }

--- a/front-end/src/features/service/api/service.api.ts
+++ b/front-end/src/features/service/api/service.api.ts
@@ -4,6 +4,13 @@ import { Service } from "@/features/service/types";
 import { ImageUrl } from "@/features/shared/types";
 import { uploadFile } from "@/features/upload/upload.api"; // highlight-line
 import apiClient from "@/lib/apiClient";
+import { buildQueryString } from "@/lib/queryString";
+
+export interface GetServicesParams {
+  skip?: number;
+  limit?: number;
+  search?: string;
+}
 
 /**
  * Xử lý upload các file mới và trả về danh sách ImageUrl hoàn chỉnh.
@@ -58,7 +65,7 @@ export async function addService(
 
   console.log("Payload to send for addService:", payload);
 
-  return apiClient<Service>("/services/services", {
+  return apiClient<Service>("/services", {
     method: "POST",
     body: JSON.stringify(payload),
   });
@@ -89,7 +96,7 @@ export async function updateService({
 
   console.log("Payload to send for updateService:", payload);
 
-  return apiClient<Service>(`/services/services/${serviceId}`, {
+  return apiClient<Service>(`/services/${serviceId}`, {
     method: "PUT",
     body: JSON.stringify(payload),
   });
@@ -98,8 +105,9 @@ export async function updateService({
 /**
  * Lấy danh sách tất cả dịch vụ
  */
-export async function getServices(): Promise<Service[]> {
-  return apiClient<Service[]>("/services");
+export async function getServices(params?: GetServicesParams): Promise<Service[]> {
+  const query = buildQueryString(params);
+  return apiClient<Service[]>(`/services${query}`);
 }
 
 /**
@@ -107,7 +115,7 @@ export async function getServices(): Promise<Service[]> {
  * @param id ID của dịch vụ
  */
 export async function getServiceById(id: string): Promise<Service> {
-  return apiClient<Service>(`/services/services/${id}`);
+  return apiClient<Service>(`/services/${id}`);
 }
 
 /**
@@ -115,7 +123,7 @@ export async function getServiceById(id: string): Promise<Service> {
  * @param serviceId ID của dịch vụ cần xóa
  */
 export async function deleteService(serviceId: string): Promise<void> {
-  return apiClient<void>(`/services/services/${serviceId}`, {
+  return apiClient<void>(`/services/${serviceId}`, {
     method: "DELETE",
   });
 }

--- a/front-end/src/features/service/types.ts
+++ b/front-end/src/features/service/types.ts
@@ -10,14 +10,13 @@ export interface Service {
   categories: Category[];
   images: ImageUrl[];
   primary_image_id?: string | null;
-  status: "active" | "inactive";
-  preparation_notes: string;
-  aftercare_instructions: string;
-  contraindications: string;
-  is_deleted: boolean;
+  preparation_notes?: string | null;
+  aftercare_instructions?: string | null;
+  contraindications?: string | null;
+  is_deleted?: boolean;
   consumables?: ServiceConsumable[];
-  created_at: Date;
-  updated_at: Date;
+  created_at?: string;
+  updated_at?: string;
 }
 export interface ServiceConsumable {
   productId: string;

--- a/front-end/src/features/treatment/api/treatment.api.ts
+++ b/front-end/src/features/treatment/api/treatment.api.ts
@@ -1,6 +1,7 @@
 // src/features/treatment/api/treatment.api.ts
 import { TreatmentPlan } from "@/features/treatment/types";
 import apiClient from "@/lib/apiClient";
+import { buildQueryString } from "@/lib/queryString";
 import { TreatmentPlanFormValues } from "@/features/treatment/schemas";
 import { ImageUrl } from "@/features/shared/types";
 import { uploadFile } from "@/features/upload/upload.api";
@@ -78,8 +79,17 @@ export async function updateTreatmentPlan({
 /**
  * Lấy danh sách tất cả các liệu trình
  */
-export const getTreatmentPlans = async (): Promise<TreatmentPlan[]> => {
-  return apiClient<TreatmentPlan[]>("/treatment-plans");
+export interface GetTreatmentPlansParams {
+  skip?: number;
+  limit?: number;
+  search?: string;
+}
+
+export const getTreatmentPlans = async (
+  params?: GetTreatmentPlansParams
+): Promise<TreatmentPlan[]> => {
+  const query = buildQueryString(params);
+  return apiClient<TreatmentPlan[]>(`/treatment-plans${query}`);
 };
 
 /**

--- a/front-end/src/features/treatment/types.ts
+++ b/front-end/src/features/treatment/types.ts
@@ -1,25 +1,28 @@
+import { Category } from "@/features/category/types";
 import { ImageUrl } from "@/features/shared/types";
+import type { Service } from "@/features/service/types";
 
 export interface TreatmentPlanStep {
+  id: string;
   step_number: number;
   service_id: string;
-  description?: string;
+  description?: string | null;
+  service?: Service;
 }
 
 export interface TreatmentPlan {
   id: string;
   name: string;
   description: string;
-  categories: string[];
+  category: Category;
   steps: TreatmentPlanStep[];
   price: number;
   total_sessions: number;
   images: ImageUrl[];
   primary_image_id?: string | null;
-  status: "active" | "inactive";
-  is_deleted: boolean;
-  created_at: Date;
-  updated_at: Date;
+  is_deleted?: boolean;
+  created_at?: string;
+  updated_at?: string;
 }
 
 export interface TreatmentSession {
@@ -28,19 +31,19 @@ export interface TreatmentSession {
   appointment_id?: string; // Liên kết tới lịch hẹn cụ thể
   status: "completed" | "upcoming" | "cancelled";
   notes?: string;
-  completed_at?: Date;
+  completed_at?: string;
 }
 
 export interface TreatmentPackage {
   id: string;
   customer_id: string;
   treatment_plan_id: string;
-  purchase_date: Date;
+  purchase_date: string;
   purchase_invoice_id: string;
   total_sessions: number;
   completed_sessions: number;
   sessions: TreatmentSession[];
-  is_deleted: boolean;
-  created_at: Date;
-  updated_at: Date;
+  is_deleted?: boolean;
+  created_at?: string;
+  updated_at?: string;
 }

--- a/front-end/src/lib/queryString.ts
+++ b/front-end/src/lib/queryString.ts
@@ -1,0 +1,26 @@
+// src/lib/queryString.ts
+
+/**
+ * Tạo chuỗi query string từ một object các tham số.
+ * Tự động loại bỏ các giá trị null/undefined.
+ */
+export function buildQueryString(
+  params?: Record<string, string | number | boolean | null | undefined>
+): string {
+  if (!params) {
+    return "";
+  }
+
+  const searchParams = new URLSearchParams();
+
+  Object.entries(params).forEach(([key, value]) => {
+    if (value === undefined || value === null) {
+      return;
+    }
+
+    searchParams.set(key, String(value));
+  });
+
+  const queryString = searchParams.toString();
+  return queryString ? `?${queryString}` : "";
+}


### PR DESCRIPTION
## Summary
- connect the public homepage, product, promotion, and treatment plan screens to live service, product, treatment, and promotion APIs with graceful empty/error states
- add reusable UI building blocks (data state banner, skeleton cards, route-level loading skeletons) to improve perceived performance while data loads
- harden API utilities with richer error information, query string helpers, and aligned type definitions for catalog entities

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e28ba06c8c832883aa701c1440acea