### PR TITLE
Use Next.js Link for auth navigation

### DIFF
--- a/front-end/src/features/auth/components/forgot-password-form.tsx
+++ b/front-end/src/features/auth/components/forgot-password-form.tsx
@@ -1,6 +1,7 @@
 // src/features/auth/components/forgot-password-form.tsx
 "use client";
 
+import Link from "next/link";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import * as z from "zod";
@@ -105,12 +106,12 @@ export const ForgotPasswordForm = () => {
           <CardFooter>
             <p className="text-sm text-muted-foreground text-center w-full">
               Nhớ mật khẩu rồi?{" "}
-              <a
+              <Link
                 className="text-primary hover:underline font-medium"
                 href="/auth/login"
               >
                 Đăng nhập
-              </a>
+              </Link>
             </p>
           </CardFooter>
         </form>

--- a/front-end/src/features/auth/components/login-form.tsx
+++ b/front-end/src/features/auth/components/login-form.tsx
@@ -6,6 +6,8 @@ import { useForm } from "react-hook-form";
 import { FcGoogle } from "react-icons/fc";
 import * as z from "zod";
 
+import Link from "next/link";
+
 import { PasswordInput } from "@/components/common/password-input";
 import { Button } from "@/components/ui/button";
 import {
@@ -103,12 +105,12 @@ export const LoginForm = () => {
                 <FormItem>
                   <div className="flex items-center justify-between">
                     <FormLabel>Mật khẩu</FormLabel>
-                    <a
+                    <Link
                       href="/auth/forgot-password"
                       className="text-sm font-medium text-primary hover:underline"
                     >
                       Quên mật khẩu?
-                    </a>
+                    </Link>
                   </div>
                   <FormControl>
                     <PasswordInput
@@ -128,12 +130,12 @@ export const LoginForm = () => {
           <CardFooter className="flex flex-col gap-4 mt-4">
             <p className="text-sm text-muted-foreground text-center w-full">
               Chưa có tài khoản?{" "}
-              <a
+              <Link
                 className="text-primary hover:underline font-medium"
                 href="/auth/register"
               >
                 Đăng ký tại đây
-              </a>
+              </Link>
             </p>
           </CardFooter>
         </form>

--- a/front-end/src/features/auth/components/register-form.tsx
+++ b/front-end/src/features/auth/components/register-form.tsx
@@ -6,6 +6,8 @@ import { useTransition } from "react";
 import { useForm } from "react-hook-form";
 import * as z from "zod";
 
+import Link from "next/link";
+
 import { PasswordInput } from "@/components/common/password-input";
 import { Button } from "@/components/ui/button";
 import {
@@ -128,12 +130,12 @@ export const RegisterForm = () => {
           <CardFooter className="flex flex-col items-center gap-2 mt-4">
             <p className="text-sm text-muted-foreground text-center w-full">
               Đã có tài khoản?{" "}
-              <a
+              <Link
                 className="text-primary hover:underline font-medium"
                 href="/auth/login"
               >
                 Đăng nhập tại đây
-              </a>
+              </Link>
             </p>
           </CardFooter>
         </form>


### PR DESCRIPTION
## Summary
- replace plain anchor tags in the auth forms with Next.js `Link` components to ensure client-side navigation between login, register, and password reset views
- import the shared `Link` dependency in each form component to keep the code tidy and consistent

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e295c6e3b88328931a76c8f6b908ef