### PR TITLE
Refactor admin navigation layout components

### DIFF
--- a/front-end/src/components/layout/admin/header.tsx
+++ b/front-end/src/components/layout/admin/header.tsx
@@ -1,7 +1,9 @@
 // src/components/layout/admin/header.tsx
 "use client";
 
+import { useState } from "react";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -12,19 +14,34 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
 import { useAuth } from "@/contexts/AuthContexts";
-import { LogOut, Menu, Moon, Search, Settings, Sun, User } from "lucide-react";
+import {
+  Bell,
+  LogOut,
+  Menu,
+  Moon,
+  Search,
+  Settings,
+  Sun,
+  User,
+} from "lucide-react";
 import { useTheme } from "next-themes";
 import { AdminSidebar } from "./sidebar"; // Import sidebar cho mobile
 
 export function AdminHeader() {
   const { user, logout } = useAuth();
   const { theme, setTheme } = useTheme();
+  const [isSidebarOpen, setIsSidebarOpen] = useState(false);
+
+  // TODO: Replace with API driven notification count
+  const unreadNotifications = 3;
+  const hasUnreadNotifications = unreadNotifications > 0;
 
   return (
-    <header className="flex h-14 items-center gap-4 border-b bg-background px-4 lg:h-[60px] lg:px-6 sticky top-0 z-40">
-      <Sheet>
+    <header className="sticky top-0 z-40 flex h-14 items-center gap-4 border-b bg-background px-4 lg:h-[60px] lg:px-6">
+      <Sheet open={isSidebarOpen} onOpenChange={setIsSidebarOpen}>
         <SheetTrigger asChild>
           <Button variant="outline" size="icon" className="shrink-0 lg:hidden">
             <Menu className="h-5 w-5" />
@@ -32,32 +49,61 @@ export function AdminHeader() {
           </Button>
         </SheetTrigger>
         <SheetContent side="left" className="flex flex-col p-0">
-          {/* Nhúng Sidebar vào đây cho bản mobile */}
-          <AdminSidebar />
+          <AdminSidebar variant="mobile" onNavigate={() => setIsSidebarOpen(false)} />
         </SheetContent>
       </Sheet>
 
       <div className="w-full flex-1">
-        <form>
-          <div className="relative">
-            <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+        <form role="search" className="max-w-full">
+          <Label htmlFor="admin-search" className="sr-only">
+            Tìm kiếm trong bảng điều khiển
+          </Label>
+          <div className="relative md:w-2/3 lg:w-1/3">
+            <Search
+              className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground"
+              aria-hidden="true"
+            />
             <Input
+              id="admin-search"
               type="search"
-              placeholder="Tìm kiếm..."
-              className="w-full appearance-none bg-muted pl-8 shadow-none md:w-2/3 lg:w-1/3"
+              placeholder="Tìm kiếm khách hàng, đơn hàng..."
+              className="w-full appearance-none bg-muted pl-8 pr-4 shadow-none"
             />
           </div>
         </form>
       </div>
-      <Button
-        variant="outline"
-        size="icon"
-        onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
-      >
-        <Sun className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
-        <Moon className="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
-        <span className="sr-only">Toggle theme</span>
-      </Button>
+      <div className="flex items-center gap-2">
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="relative"
+          aria-label={
+            hasUnreadNotifications
+              ? `Có ${unreadNotifications} thông báo chưa đọc`
+              : "Xem thông báo"
+          }
+        >
+          <Bell className="h-5 w-5" aria-hidden="true" />
+          {hasUnreadNotifications && (
+            <Badge
+              variant="destructive"
+              className="absolute -right-1 -top-1 h-5 min-w-[1.25rem] rounded-full px-1 py-0 text-[0.65rem] leading-[1.1]"
+            >
+              {unreadNotifications}
+            </Badge>
+          )}
+        </Button>
+        <Button
+          variant="outline"
+          size="icon"
+          onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
+        >
+          <Sun className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
+          <Moon className="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+          <span className="sr-only">Toggle theme</span>
+        </Button>
+      </div>
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <Button variant="secondary" size="icon" className="rounded-full">

--- a/front-end/src/components/layout/admin/sidebar.tsx
+++ b/front-end/src/components/layout/admin/sidebar.tsx
@@ -2,58 +2,78 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import {
-  LayoutDashboard,
-  ShoppingCart,
-  Users,
-  ClipboardList,
-  Tag,
-  Sparkles,
-  Scissors,
-  UserCog,
-} from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { adminBrand, adminNavigation } from "@/config/admin-navigation";
+import { cn } from "@/lib/utils";
 
-const navLinks = [
-  { href: "/dashboard", label: "Tổng quan", icon: LayoutDashboard },
-  { href: "/dashboard/orders", label: "Đơn hàng", icon: ShoppingCart },
-  { href: "/dashboard/customers", label: "Khách hàng", icon: Users },
-  { href: "/dashboard/appointments", label: "Lịch hẹn", icon: ClipboardList },
-  { href: "/dashboard/staff", label: "Nhân viên", icon: UserCog },
-  { href: "/dashboard/services", label: "Dịch vụ", icon: Scissors },
-  { href: "/dashboard/products", label: "Sản phẩm", icon: Tag },
-  { href: "/dashboard/treatments", label: "Liệu trình", icon: Sparkles },
-  { href: "/dashboard/appointments", label: "Lịch hẹn", icon: ClipboardList },
-];
+type AdminSidebarProps = {
+  /**
+   * Desktop sidebar is hidden on smaller breakpoints while mobile variant is
+   * rendered inside a sheet/drawer.
+   */
+  variant?: "desktop" | "mobile";
+  className?: string;
+  onNavigate?: () => void;
+};
 
-export function AdminSidebar() {
+export function AdminSidebar({
+  variant = "desktop",
+  className,
+  onNavigate,
+}: AdminSidebarProps) {
   const pathname = usePathname();
+  const BrandIcon = adminBrand.icon;
+
+  const getIsActive = (href: string, exact?: boolean) => {
+    if (exact) {
+      return pathname === href;
+    }
+
+    return pathname === href || pathname.startsWith(`${href}/`);
+  };
 
   return (
-    <aside className="hidden lg:flex flex-col w-64 border-r bg-background">
-      <div className="p-4 border-b">
+    <aside
+      className={cn(
+        "flex w-64 flex-col bg-background",
+        variant === "desktop"
+          ? "hidden border-r lg:flex"
+          : "flex border-r border-border/60 lg:hidden",
+        className,
+      )}
+    >
+      <div className="flex items-center gap-2 border-b p-4 font-semibold text-lg">
         <Link
-          href="/dashboard"
-          className="flex items-center gap-2 font-bold text-lg"
+          href={adminBrand.href}
+          className="flex items-center gap-2"
+          onClick={() => onNavigate?.()}
         >
-          <Sparkles className="h-6 w-6 text-primary" />
-          <span>Serenity Spa</span>
+          <BrandIcon className="h-6 w-6 text-primary" aria-hidden="true" />
+          <span>{adminBrand.name}</span>
         </Link>
       </div>
-      <nav className="flex-1 p-4 space-y-2">
-        {navLinks.map((link) => (
-          <Button
-            key={link.href}
-            asChild
-            variant={pathname === link.href ? "secondary" : "ghost"}
-            className="w-full justify-start"
-          >
-            <Link href={link.href}>
-              <link.icon className="mr-2 h-4 w-4" />
-              {link.label}
-            </Link>
-          </Button>
-        ))}
+      <nav aria-label="Điều hướng quản trị" className="flex-1 space-y-2 p-4">
+        {adminNavigation.map((item) => {
+          const isActive = getIsActive(item.href, item.exact);
+          const Icon = item.icon;
+
+          return (
+            <Button
+              key={item.href}
+              asChild
+              variant={isActive ? "secondary" : "ghost"}
+              className="w-full justify-start gap-2"
+            >
+              <Link href={item.href} onClick={() => onNavigate?.()}>
+                <Icon className="h-4 w-4" aria-hidden="true" />
+                <span>{item.label}</span>
+                {isActive && (
+                  <span className="sr-only">(đang chọn)</span>
+                )}
+              </Link>
+            </Button>
+          );
+        })}
       </nav>
     </aside>
   );

--- a/front-end/src/config/admin-navigation.ts
+++ b/front-end/src/config/admin-navigation.ts
@@ -1,0 +1,35 @@
+import type { LucideIcon } from "lucide-react";
+import {
+  ClipboardList,
+  LayoutDashboard,
+  Scissors,
+  ShoppingCart,
+  Sparkles,
+  Tag,
+  UserCog,
+  Users,
+} from "lucide-react";
+
+export type AdminNavItem = {
+  href: string;
+  label: string;
+  icon: LucideIcon;
+  exact?: boolean;
+};
+
+export const adminBrand = {
+  name: "Serenity Spa",
+  href: "/dashboard",
+  icon: Sparkles,
+};
+
+export const adminNavigation: AdminNavItem[] = [
+  { href: "/dashboard", label: "Tổng quan", icon: LayoutDashboard, exact: true },
+  { href: "/dashboard/orders", label: "Đơn hàng", icon: ShoppingCart },
+  { href: "/dashboard/customers", label: "Khách hàng", icon: Users },
+  { href: "/dashboard/appointments", label: "Lịch hẹn", icon: ClipboardList },
+  { href: "/dashboard/staff", label: "Nhân viên", icon: UserCog },
+  { href: "/dashboard/services", label: "Dịch vụ", icon: Scissors },
+  { href: "/dashboard/products", label: "Sản phẩm", icon: Tag },
+  { href: "/dashboard/treatments", label: "Liệu trình", icon: Sparkles },
+];


### PR DESCRIPTION
## Summary
- extract the admin navigation configuration and branding into a reusable config module
- refactor the admin sidebar to consume the shared config, add mobile support, and improve accessibility semantics
- update the admin header with labeled search, notification badge, and sheet-controlled sidebar on mobile

## Testing
- npm run lint (warnings only)


------
https://chatgpt.com/codex/tasks/task_e_68e29ce90ad48328a88ebc4ec546d012