### PR TITLE
Align remaining TanStack Query hooks across features

### DIFF
--- a/front-end/src/features/appointment/hooks/useAvailability.ts
+++ b/front-end/src/features/appointment/hooks/useAvailability.ts
@@ -1,6 +1,15 @@
 // src/features/appointment/hooks/useAvailability.ts
 import { useQuery } from "@tanstack/react-query";
+
 import { getAvailableSlots } from "@/features/appointment/apis/availability.api";
+
+const availabilityQueryKeys = {
+  detail: (
+    serviceId: string | undefined,
+    dateString: string | undefined,
+    technicianId?: string
+  ) => ["availability", serviceId, dateString, technicianId] as const,
+};
 
 /**
  * Custom hook để lấy các khung giờ trống.
@@ -13,10 +22,16 @@ export const useAvailability = (
   technicianId?: string // Thêm technicianId
 ) => {
   const dateString = selectedDate?.toISOString().split("T")[0];
+  const hasValidParams = Boolean(serviceId && dateString);
 
   return useQuery<string[]>({
-    queryKey: ["availability", serviceId, dateString, technicianId], // Thêm vào queryKey
-    queryFn: () => getAvailableSlots(serviceId!, dateString!, technicianId),
-    enabled: !!serviceId && !!dateString,
+    queryKey: availabilityQueryKeys.detail(serviceId, dateString, technicianId),
+    queryFn: () =>
+      getAvailableSlots(
+        serviceId as string,
+        dateString as string,
+        technicianId
+      ),
+    enabled: hasValidParams,
   });
 };

--- a/front-end/src/features/inventory/hooks/useInventory.ts
+++ b/front-end/src/features/inventory/hooks/useInventory.ts
@@ -1,24 +1,33 @@
 // src/features/inventory/hooks/useInventory.ts
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
+
 import { adjustStock } from "@/features/inventory/api/inventory.api";
-import { StockAdjustmentFormValues } from "@/features/product/schemas";
+import { productsQueryKeys } from "@/features/product/hooks/useProducts";
+import type { StockAdjustmentFormValues } from "@/features/product/schemas";
+import type { Product } from "@/features/product/types";
+import { getErrorMessage } from "@/lib/get-error-message";
 
 export const useAdjustStock = () => {
   const queryClient = useQueryClient();
 
-  return useMutation({
-    mutationFn: (payload: StockAdjustmentFormValues) => adjustStock(payload),
-    onSuccess: (updatedProduct) => {
+  return useMutation<Product, unknown, StockAdjustmentFormValues>({
+    mutationFn: adjustStock,
+    onSuccess: async (updatedProduct) => {
       toast.success(
         `Đã cập nhật tồn kho cho "${updatedProduct.name}" thành công!`
       );
-      // Làm mới lại danh sách sản phẩm để UI cập nhật
-      queryClient.invalidateQueries({ queryKey: ["products"] });
+
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: productsQueryKeys.all }),
+        queryClient.invalidateQueries({
+          queryKey: productsQueryKeys.detail(updatedProduct.id),
+        }),
+      ]);
     },
     onError: (error) => {
       toast.error("Cập nhật tồn kho thất bại", {
-        description: error.message,
+        description: getErrorMessage(error),
       });
     },
   });

--- a/front-end/src/features/product/hooks/useProducts.ts
+++ b/front-end/src/features/product/hooks/useProducts.ts
@@ -1,22 +1,29 @@
 // src/features/product/hooks/useProducts.ts
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+
 import {
   getProducts,
   addProduct,
   updateProduct,
   deleteProduct,
 } from "@/features/product/api/product.api";
-import { Product } from "@/features/product/types";
-import { ProductFormValues } from "@/features/product/schemas";
-import { toast } from "sonner";
+import type { GetProductsParams } from "@/features/product/api/product.api";
+import type { ProductFormValues } from "@/features/product/schemas";
+import type { Product } from "@/features/product/types";
+import { getErrorMessage } from "@/lib/get-error-message";
 
-const queryKey = ["products"];
+export const productsQueryKeys = {
+  all: ["products"] as const,
+  list: (params?: GetProductsParams) => ["products", { params }] as const,
+  detail: (productId: string) => ["products", productId] as const,
+};
 
 // Hook để lấy danh sách sản phẩm
-export const useProducts = () => {
+export const useProducts = (params?: GetProductsParams) => {
   return useQuery<Product[]>({
-    queryKey: queryKey,
-    queryFn: () => getProducts(),
+    queryKey: productsQueryKeys.list(params),
+    queryFn: () => getProducts(params),
     retry: 1,
     staleTime: 60 * 1000,
   });
@@ -25,14 +32,22 @@ export const useProducts = () => {
 // Hook để thêm sản phẩm mới
 export const useAddProduct = () => {
   const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: (productData: ProductFormValues) => addProduct(productData),
-    onSuccess: () => {
+
+  return useMutation<Product, unknown, ProductFormValues>({
+    mutationFn: addProduct,
+    onSuccess: async (createdProduct) => {
       toast.success("Thêm sản phẩm thành công!");
-      queryClient.invalidateQueries({ queryKey: queryKey });
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: productsQueryKeys.all }),
+        queryClient.invalidateQueries({
+          queryKey: productsQueryKeys.detail(createdProduct.id),
+        }),
+      ]);
     },
     onError: (error) => {
-      toast.error("Thêm sản phẩm thất bại", { description: error.message });
+      toast.error("Thêm sản phẩm thất bại", {
+        description: getErrorMessage(error),
+      });
     },
   });
 };
@@ -40,17 +55,26 @@ export const useAddProduct = () => {
 // Hook để cập nhật sản phẩm
 export const useUpdateProduct = () => {
   const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: (data: {
-      productId: string;
-      productData: Partial<ProductFormValues>;
-    }) => updateProduct(data),
-    onSuccess: () => {
+
+  return useMutation<
+    Product,
+    unknown,
+    Parameters<typeof updateProduct>[0]
+  >({
+    mutationFn: updateProduct,
+    onSuccess: async (_, variables) => {
       toast.success("Cập nhật thông tin thành công!");
-      queryClient.invalidateQueries({ queryKey: queryKey });
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: productsQueryKeys.all }),
+        queryClient.invalidateQueries({
+          queryKey: productsQueryKeys.detail(variables.productId),
+        }),
+      ]);
     },
     onError: (error) => {
-      toast.error("Cập nhật thất bại", { description: error.message });
+      toast.error("Cập nhật thất bại", {
+        description: getErrorMessage(error),
+      });
     },
   });
 };
@@ -58,14 +82,22 @@ export const useUpdateProduct = () => {
 // Hook để xóa sản phẩm
 export const useDeleteProduct = () => {
   const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: (productId: string) => deleteProduct(productId),
-    onSuccess: () => {
+
+  return useMutation<void, unknown, string>({
+    mutationFn: deleteProduct,
+    onSuccess: async (_, productId) => {
       toast.success("Đã xóa sản phẩm!");
-      queryClient.invalidateQueries({ queryKey: queryKey });
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: productsQueryKeys.all }),
+        queryClient.invalidateQueries({
+          queryKey: productsQueryKeys.detail(productId),
+        }),
+      ]);
     },
     onError: (error) => {
-      toast.error("Xóa thất bại", { description: error.message });
+      toast.error("Xóa thất bại", {
+        description: getErrorMessage(error),
+      });
     },
   });
 };

--- a/front-end/src/features/service/hooks/useServices.ts
+++ b/front-end/src/features/service/hooks/useServices.ts
@@ -7,13 +7,17 @@ import {
 } from "@/features/service/api/service.api";
 import { Service } from "@/features/service/types";
 import { toast } from "sonner";
+import { getErrorMessage } from "@/lib/get-error-message";
+import { ServiceFormValues } from "@/features/service/schemas";
 
-const queryKey = ["services"];
+const servicesQueryKeys = {
+  all: ["services"] as const,
+};
 
 // Hook để lấy danh sách dịch vụ
 export const useServices = () => {
   return useQuery<Service[]>({
-    queryKey: queryKey,
+    queryKey: servicesQueryKeys.all,
     queryFn: getServices,
   });
 };
@@ -21,14 +25,17 @@ export const useServices = () => {
 // Hook để thêm dịch vụ mới
 export const useAddService = () => {
   const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: addService,
-    onSuccess: () => {
+
+  return useMutation<Service, unknown, ServiceFormValues>({
+    mutationFn: (serviceData) => addService(serviceData),
+    onSuccess: async () => {
       toast.success("Thêm dịch vụ thành công!");
-      queryClient.invalidateQueries({ queryKey: queryKey });
+      await queryClient.invalidateQueries({ queryKey: servicesQueryKeys.all });
     },
     onError: (error) => {
-      toast.error("Thêm dịch vụ thất bại", { description: error.message });
+      toast.error("Thêm dịch vụ thất bại", {
+        description: getErrorMessage(error),
+      });
     },
   });
 };
@@ -36,14 +43,22 @@ export const useAddService = () => {
 // Hook để cập nhật dịch vụ
 export const useUpdateService = () => {
   const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: updateService,
-    onSuccess: () => {
+
+  return useMutation<
+    Service,
+    unknown,
+    { serviceId: string; serviceData: Partial<ServiceFormValues> }
+  >({
+    mutationFn: ({ serviceId, serviceData }) =>
+      updateService({ serviceId, serviceData }),
+    onSuccess: async () => {
       toast.success("Cập nhật thông tin thành công!");
-      queryClient.invalidateQueries({ queryKey: queryKey });
+      await queryClient.invalidateQueries({ queryKey: servicesQueryKeys.all });
     },
     onError: (error) => {
-      toast.error("Cập nhật thất bại", { description: error.message });
+      toast.error("Cập nhật thất bại", {
+        description: getErrorMessage(error),
+      });
     },
   });
 };
@@ -51,14 +66,17 @@ export const useUpdateService = () => {
 // Hook để xóa dịch vụ
 export const useDeleteService = () => {
   const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: deleteService,
-    onSuccess: () => {
+
+  return useMutation<void, unknown, string>({
+    mutationFn: (serviceId) => deleteService(serviceId),
+    onSuccess: async () => {
       toast.success("Đã xóa dịch vụ!");
-      queryClient.invalidateQueries({ queryKey: queryKey });
+      await queryClient.invalidateQueries({ queryKey: servicesQueryKeys.all });
     },
     onError: (error) => {
-      toast.error("Xóa thất bại", { description: error.message });
+      toast.error("Xóa thất bại", {
+        description: getErrorMessage(error),
+      });
     },
   });
 };

--- a/front-end/src/lib/get-error-message.ts
+++ b/front-end/src/lib/get-error-message.ts
@@ -1,0 +1,23 @@
+export const getErrorMessage = (
+  error: unknown,
+  fallbackMessage = "Đã xảy ra lỗi không xác định."
+): string => {
+  if (typeof error === "string" && error.trim().length > 0) {
+    return error;
+  }
+
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+
+  if (
+    typeof error === "object" &&
+    error !== null &&
+    "message" in error &&
+    typeof (error as { message: unknown }).message === "string"
+  ) {
+    return (error as { message: string }).message;
+  }
+
+  return fallbackMessage;
+};


### PR DESCRIPTION
## Summary
- unify TanStack Query hooks for staff, products, inventory, schedule, and availability with shared query key helpers and error handling
- expose reusable product query keys and ensure mutations invalidate both list and detail caches after success
- streamline availability hook parameters to keep query cache scoped to service, date, and technician inputs

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e367f735388328b18d79a3a02efd1c