### PR TITLE
Fix query function signatures in React Query hooks

### DIFF
--- a/front-end/src/features/appointment/hooks/useAppointments.ts
+++ b/front-end/src/features/appointment/hooks/useAppointments.ts
@@ -24,7 +24,7 @@ type UpdateAppointmentVariables = {
 export const useAppointments = () => {
   return useQuery<Appointment[]>({
     queryKey: appointmentsQueryKeys.all,
-    queryFn: getAppointments,
+    queryFn: () => getAppointments(),
   });
 };
 

--- a/front-end/src/features/category/hooks/useCategories.ts
+++ b/front-end/src/features/category/hooks/useCategories.ts
@@ -5,6 +5,6 @@ import { Category } from "@/features/category/types";
 export const useCategories = () => {
   return useQuery<Category[]>({
     queryKey: ["categories"],
-    queryFn: getCategories,
+    queryFn: () => getCategories(),
   });
 };

--- a/front-end/src/features/customer/hooks/useCustomerProfile.ts
+++ b/front-end/src/features/customer/hooks/useCustomerProfile.ts
@@ -9,9 +9,11 @@ const getCustomerProfile = (): Promise<FullCustomerProfile> => {
 };
 
 export const useCustomerProfile = () => {
+  const { user } = useAuth();
+
   return useQuery<FullCustomerProfile>({
     queryKey: ["customerProfile", "me"],
-    queryFn: getCustomerProfile,
-    enabled: !!useAuth().user, // Chỉ chạy khi đã đăng nhập
+    queryFn: () => getCustomerProfile(),
+    enabled: !!user, // Chỉ chạy khi đã đăng nhập
   });
 };

--- a/front-end/src/features/customer/hooks/useCustomers.ts
+++ b/front-end/src/features/customer/hooks/useCustomers.ts
@@ -5,6 +5,6 @@ import { FullCustomerProfile } from "@/features/customer/types";
 export const useCustomers = () => {
   return useQuery<FullCustomerProfile[]>({
     queryKey: ["customers"],
-    queryFn: getCustomers,
+    queryFn: () => getCustomers(),
   });
 };

--- a/front-end/src/features/review/hooks/useReviews.ts
+++ b/front-end/src/features/review/hooks/useReviews.ts
@@ -5,6 +5,6 @@ import { Review } from "@/features/review/types";
 export const useReviews = () => {
   return useQuery<Review[]>({
     queryKey: ["reviews"],
-    queryFn: getReviews,
+    queryFn: () => getReviews(),
   });
 };

--- a/front-end/src/features/service/hooks/useServices.ts
+++ b/front-end/src/features/service/hooks/useServices.ts
@@ -18,7 +18,7 @@ const servicesQueryKeys = {
 export const useServices = () => {
   return useQuery<Service[]>({
     queryKey: servicesQueryKeys.all,
-    queryFn: getServices,
+    queryFn: () => getServices(),
   });
 };
 

--- a/front-end/src/features/staff/hooks/useStaff.ts
+++ b/front-end/src/features/staff/hooks/useStaff.ts
@@ -25,7 +25,7 @@ export const staffQueryKeys = {
 export const useStaff = () => {
   return useQuery<FullStaffProfile[]>({
     queryKey: staffQueryKeys.all,
-    queryFn: getStaffList,
+    queryFn: () => getStaffList(),
   });
 };
 

--- a/front-end/src/features/treatment/hooks/useTreatmentPlans.ts
+++ b/front-end/src/features/treatment/hooks/useTreatmentPlans.ts
@@ -5,6 +5,6 @@ import { TreatmentPlan } from "@/features/treatment/types";
 export const useTreatmentPlans = () => {
   return useQuery<TreatmentPlan[]>({
     queryKey: ["treatmentPlans"],
-    queryFn: getTreatmentPlans,
+    queryFn: () => getTreatmentPlans(),
   });
 };

--- a/front-end/src/features/user/hooks/useRoles.ts
+++ b/front-end/src/features/user/hooks/useRoles.ts
@@ -5,6 +5,6 @@ import { Role } from "@/features/user/types";
 export const useRoles = () => {
   return useQuery<Role[]>({
     queryKey: ["roles"],
-    queryFn: getRoles,
+    queryFn: () => getRoles(),
   });
 };


### PR DESCRIPTION
## Summary
- wrap each hook's `queryFn` in a zero-argument callback to satisfy TanStack Query v5 typing requirements
- cache the auth context inside `useCustomerProfile` before configuring the query options

## Testing
- pnpm --filter front-end lint

------
https://chatgpt.com/codex/tasks/task_e_68e36c20a61c83289baba97a08560053