### PR TITLE
feat: hỗ trợ thư viện ảnh dùng chung cho nhiều đối tượng

### DIFF
--- a/back-end/app/api/images_api.py
+++ b/back-end/app/api/images_api.py
@@ -19,9 +19,9 @@ async def upload_image(
     session: Session = Depends(get_db_session),
     file: UploadFile = File(...),
     alt_text: Optional[str] = Form(None),
-    product_id: Optional[uuid.UUID] = Form(None),
-    service_id: Optional[uuid.UUID] = Form(None),
-    treatment_plan_id: Optional[uuid.UUID] = Form(None),
+    product_ids: Optional[List[uuid.UUID]] = Form(None),
+    service_ids: Optional[List[uuid.UUID]] = Form(None),
+    treatment_plan_ids: Optional[List[uuid.UUID]] = Form(None),
 ):
     """Tải ảnh lên kho lưu trữ và lưu metadata."""
 
@@ -29,9 +29,9 @@ async def upload_image(
         db=session,
         file=file,
         alt_text=alt_text,
-        product_id=product_id,
-        service_id=service_id,
-        treatment_plan_id=treatment_plan_id,
+        product_ids=product_ids or [],
+        service_ids=service_ids or [],
+        treatment_plan_ids=treatment_plan_ids or [],
     )
 
 

--- a/back-end/app/models/association_tables.py
+++ b/back-end/app/models/association_tables.py
@@ -25,3 +25,39 @@ class ProductCategoryLink(SQLModel, table=True):
         foreign_key="category.id",
         primary_key=True,
     )
+
+
+class ProductImageLink(SQLModel, table=True):
+    __tablename__ = "product_image_link"
+    product_id: uuid.UUID = Field(
+        foreign_key="product.id",
+        primary_key=True,
+    )
+    image_id: uuid.UUID = Field(
+        foreign_key="image.id",
+        primary_key=True,
+    )
+
+
+class ServiceImageLink(SQLModel, table=True):
+    __tablename__ = "service_image_link"
+    service_id: uuid.UUID = Field(
+        foreign_key="service.id",
+        primary_key=True,
+    )
+    image_id: uuid.UUID = Field(
+        foreign_key="image.id",
+        primary_key=True,
+    )
+
+
+class TreatmentPlanImageLink(SQLModel, table=True):
+    __tablename__ = "treatment_plan_image_link"
+    treatment_plan_id: uuid.UUID = Field(
+        foreign_key="treatment_plan.id",
+        primary_key=True,
+    )
+    image_id: uuid.UUID = Field(
+        foreign_key="image.id",
+        primary_key=True,
+    )

--- a/back-end/app/models/catalog_model.py
+++ b/back-end/app/models/catalog_model.py
@@ -5,7 +5,13 @@ from sqlmodel import SQLModel, Field, Relationship
 from app.models.base_model import BaseUUIDModel
 
 # Import bảng liên kết mới
-from app.models.association_tables import ProductCategoryLink, ServiceCategoryLink
+from app.models.association_tables import (
+    ProductCategoryLink,
+    ProductImageLink,
+    ServiceCategoryLink,
+    ServiceImageLink,
+    TreatmentPlanImageLink,
+)
 
 if TYPE_CHECKING:
     from app.models.services_model import Service
@@ -35,21 +41,30 @@ class Image(BaseUUIDModel, table=True):
     __tablename__ = "image"
     url: str = Field(nullable=False)
     alt_text: Optional[str] = Field(default=None)
-    service_id: Optional[uuid.UUID] = Field(default=None, foreign_key="service.id")
-    product_id: Optional[uuid.UUID] = Field(default=None, foreign_key="product.id")
-    treatment_plan_id: Optional[uuid.UUID] = Field(
-        default=None, foreign_key="treatment_plan.id"
+
+    products: List["Product"] = Relationship(
+        back_populates="images", link_model=ProductImageLink
     )
-    service: Optional["Service"] = Relationship(
-        back_populates="images",
-        sa_relationship_kwargs={"foreign_keys": "Image.service_id"},
+    services: List["Service"] = Relationship(
+        back_populates="images", link_model=ServiceImageLink
     )
-    product: Optional["Product"] = Relationship(
-        back_populates="images",
-        sa_relationship_kwargs={"foreign_keys": "Image.product_id"},
+    treatment_plans: List["TreatmentPlan"] = Relationship(
+        back_populates="images", link_model=TreatmentPlanImageLink
     )
-    treatment_plan: Optional["TreatmentPlan"] = Relationship(
-        back_populates="images",
-        sa_relationship_kwargs={"foreign_keys": "Image.treatment_plan_id"},
-    )
+
+    @property
+    def product_ids(self) -> List[uuid.UUID]:
+        return [product.id for product in self.products if not product.is_deleted]
+
+    @property
+    def service_ids(self) -> List[uuid.UUID]:
+        return [service.id for service in self.services if not service.is_deleted]
+
+    @property
+    def treatment_plan_ids(self) -> List[uuid.UUID]:
+        return [
+            treatment_plan.id
+            for treatment_plan in self.treatment_plans
+            if not treatment_plan.is_deleted
+        ]
 

--- a/back-end/app/models/products_model.py
+++ b/back-end/app/models/products_model.py
@@ -3,7 +3,7 @@ import uuid
 from typing import List, Optional, TYPE_CHECKING
 from sqlmodel import Field, Relationship
 from app.models.base_model import BaseUUIDModel
-from app.models.association_tables import ProductCategoryLink
+from app.models.association_tables import ProductCategoryLink, ProductImageLink
 
 if TYPE_CHECKING:
     from app.models.catalog_model import Category, Image
@@ -25,8 +25,7 @@ class Product(BaseUUIDModel, table=True):
         back_populates="products", link_model=ProductCategoryLink
     )
     images: List["Image"] = Relationship(
-        back_populates="product",
-        sa_relationship_kwargs={"foreign_keys": "Image.product_id"},
+        back_populates="products", link_model=ProductImageLink
     )
     primary_image_id: Optional[uuid.UUID] = Field(
         default=None, foreign_key="image.id", nullable=True

--- a/back-end/app/models/services_model.py
+++ b/back-end/app/models/services_model.py
@@ -5,7 +5,7 @@ from sqlmodel import Field, Relationship
 from app.models.base_model import BaseUUIDModel
 
 # Import bảng liên kết mới
-from app.models.association_tables import ServiceCategoryLink
+from app.models.association_tables import ServiceCategoryLink, ServiceImageLink
 
 if TYPE_CHECKING:
     from app.models.catalog_model import Category, Image
@@ -39,8 +39,7 @@ class Service(BaseUUIDModel, table=True):
     )
 
     images: List["Image"] = Relationship(
-        back_populates="service",
-        sa_relationship_kwargs={"foreign_keys": "Image.service_id"},
+        back_populates="services", link_model=ServiceImageLink
     )
     primary_image_id: Optional[uuid.UUID] = Field(
         default=None, foreign_key="image.id", nullable=True

--- a/back-end/app/models/treatment_plans_model.py
+++ b/back-end/app/models/treatment_plans_model.py
@@ -3,6 +3,7 @@ import uuid
 from typing import List, Optional, TYPE_CHECKING
 from sqlmodel import Field, Relationship
 from app.models.base_model import BaseUUIDModel
+from app.models.association_tables import TreatmentPlanImageLink
 
 if TYPE_CHECKING:
     from app.models.catalog_model import Category, Image
@@ -31,8 +32,7 @@ class TreatmentPlan(BaseUUIDModel, table=True):
     category_id: uuid.UUID = Field(foreign_key="category.id")
     category: "Category" = Relationship(back_populates="treatment_plans")
     images: List["Image"] = Relationship(
-        back_populates="treatment_plan",
-        sa_relationship_kwargs={"foreign_keys": "Image.treatment_plan_id"},
+        back_populates="treatment_plans", link_model=TreatmentPlanImageLink
     )
     primary_image_id: Optional[uuid.UUID] = Field(
         default=None, foreign_key="image.id", nullable=True

--- a/back-end/app/schemas/catalog_schema.py
+++ b/back-end/app/schemas/catalog_schema.py
@@ -16,6 +16,10 @@ class ImageBase(SQLModel):
 
 class ImagePublic(ImageBase):
     id: uuid.UUID
+    product_ids: list[uuid.UUID] = Field(default_factory=list)
+    service_ids: list[uuid.UUID] = Field(default_factory=list)
+    treatment_plan_ids: list[uuid.UUID] = Field(default_factory=list)
+
     model_config = {"from_attributes": True}
 
 


### PR DESCRIPTION
## Summary
- bổ sung các bảng liên kết để dùng chung kho hình ảnh giữa sản phẩm, dịch vụ và liệu trình
- cập nhật models, schemas, service ảnh và API để thao tác với quan hệ nhiều-nhiều và trả về danh sách ID liên kết

## Testing
- `pytest` *(thất bại: thiếu gói fastapi trong môi trường kiểm thử)*

------
https://chatgpt.com/codex/tasks/task_e_68e37e324c1883288fbb18f08d13fb69