### PR TITLE
feat: support new linked image workflow on frontend

### DIFF
--- a/front-end/src/features/product/schemas.ts
+++ b/front-end/src/features/product/schemas.ts
@@ -23,6 +23,7 @@ export const productFormSchema = z
     baseUnit: z.string().trim().min(1, "Đơn vị cơ sở không được để trống."),
     consumableUnit: z.string().optional(),
     conversionRate: z.number().optional(),
+    primary_image_id: z.string().uuid().optional(),
   })
   .refine((data) => data.isRetail || data.isConsumable, {
     message: "Sản phẩm phải là hàng bán lẻ hoặc hàng tiêu hao (hoặc cả hai).",

--- a/front-end/src/features/service/schemas.ts
+++ b/front-end/src/features/service/schemas.ts
@@ -25,6 +25,7 @@ export const serviceFormSchema = z.object({
   aftercare_instructions: z.string().optional(),
   contraindications: z.string().optional(),
   images: z.array(imageUnionSchema).optional(),
+  primary_image_id: z.string().uuid().optional(),
   is_deleted: z.boolean().optional(),
 });
 

--- a/front-end/src/features/shared/types.ts
+++ b/front-end/src/features/shared/types.ts
@@ -1,5 +1,8 @@
 export interface ImageUrl {
   id: string;
   url: string;
-  alt_text?: string;
+  alt_text?: string | null;
+  product_ids?: string[];
+  service_ids?: string[];
+  treatment_plan_ids?: string[];
 }

--- a/front-end/src/features/upload/upload.api.ts
+++ b/front-end/src/features/upload/upload.api.ts
@@ -1,19 +1,39 @@
 // src/features/upload/upload.api.ts
-import apiClient from "@/lib/apiClient";
 import { ImageUrl } from "@/features/shared/types";
 
-// Giả sử backend trả về một đối tượng ImageUrl sau khi upload thành công
-// Bạn cần một endpoint backend, ví dụ: /uploads, để xử lý việc này
-const UPLOAD_ENDPOINT = "/uploads";
+// Endpoint mới cho dịch vụ upload hình ảnh dùng chung
+const UPLOAD_ENDPOINT = "/images";
+
+type UploadImageOptions = {
+  altText?: string;
+  productIds?: string[];
+  serviceIds?: string[];
+  treatmentPlanIds?: string[];
+};
 
 /**
  * Tải một file lên server.
  * @param file Đối tượng File cần tải lên.
  * @returns Promise chứa thông tin ảnh đã được tải lên (ImageUrl).
  */
-export async function uploadFile(file: File): Promise<ImageUrl> {
+export async function uploadFile(
+  file: File,
+  options: UploadImageOptions = {}
+): Promise<ImageUrl> {
   const formData = new FormData();
   formData.append("file", file);
+
+  if (options.altText) {
+    formData.append("alt_text", options.altText);
+  }
+
+  options.productIds?.forEach((id) =>
+    formData.append("product_ids", id)
+  );
+  options.serviceIds?.forEach((id) => formData.append("service_ids", id));
+  options.treatmentPlanIds?.forEach((id) =>
+    formData.append("treatment_plan_ids", id)
+  );
 
   // Chúng ta không dùng apiClient gốc vì nó mặc định gửi JSON.
   // Thay vào đó, tạo một yêu cầu fetch riêng cho multipart/form-data.

--- a/front-end/src/lib/form-data-utils.ts
+++ b/front-end/src/lib/form-data-utils.ts
@@ -1,0 +1,51 @@
+import { ImageUrl } from "@/features/shared/types";
+
+export function appendFormDataValue(
+  formData: FormData,
+  key: string,
+  value: string | number | boolean | Blob | null | undefined
+) {
+  if (value === undefined || value === null) {
+    return;
+  }
+
+  if (value instanceof Blob) {
+    formData.append(key, value);
+    return;
+  }
+
+  formData.append(key, String(value));
+}
+
+export function appendFormDataList(
+  formData: FormData,
+  key: string,
+  values: Array<string | number | boolean | Blob>
+) {
+  values.forEach((value) => {
+    appendFormDataValue(formData, key, value);
+  });
+}
+
+export function splitImages(
+  images: (File | ImageUrl)[] | undefined
+): { files: File[]; existingIds: string[] } {
+  const result = {
+    files: [] as File[],
+    existingIds: [] as string[],
+  };
+
+  if (!images) {
+    return result;
+  }
+
+  images.forEach((image) => {
+    if (image instanceof File) {
+      result.files.push(image);
+    } else if (image?.id) {
+      result.existingIds.push(image.id);
+    }
+  });
+
+  return result;
+}


### PR DESCRIPTION
## Summary
- switch product and service API clients to submit multipart form data with existing image ids and file uploads
- add shared form-data helpers and extend image types to match the new catalog image links
- update upload API endpoint and validation schemas to accommodate linked images

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e387759a888328a5e74a0e322e1157