### PR TITLE
feat: surface shared image library in add dialogs

### DIFF
--- a/front-end/src/components/common/MultiImageUploader.tsx
+++ b/front-end/src/components/common/MultiImageUploader.tsx
@@ -1,27 +1,68 @@
 // src/components/common/MultiImageUploader.tsx
 "use client";
 
-import { useRef, useState } from "react";
-import { cn } from "@/lib/utils";
-import { Button } from "@/components/ui/button";
-import { UploadCloud, X } from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import Image from "next/image";
+import { Check, Images, Loader2, UploadCloud, X } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Separator } from "@/components/ui/separator";
 import { ImageUrl } from "@/features/shared/types";
-import { v4 as uuidv4 } from "uuid";
+import { useImageLibrary } from "@/features/upload/hooks/useImageLibrary";
+import { cn } from "@/lib/utils";
 
 interface MultiImageUploaderProps {
   onFilesSelect: (files: File[]) => void;
   value?: (File | ImageUrl)[];
   onRemoveImage: (image: File | ImageUrl) => void;
+  onLibrarySelectionChange?: (images: ImageUrl[]) => void;
 }
 
 export const MultiImageUploader = ({
   onFilesSelect,
   value = [],
   onRemoveImage,
+  onLibrarySelectionChange,
 }: MultiImageUploaderProps) => {
   const [isDragging, setIsDragging] = useState(false);
+  const [isLibraryOpen, setIsLibraryOpen] = useState(false);
+  const [selectedLibraryIds, setSelectedLibraryIds] = useState<Set<string>>(
+    new Set()
+  );
+
   const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const existingLibraryIds = useMemo(
+    () =>
+      value
+        .filter((image): image is ImageUrl => !(image instanceof File))
+        .map((image) => image.id),
+    [value]
+  );
+
+  useEffect(() => {
+    if (isLibraryOpen) {
+      setSelectedLibraryIds(new Set(existingLibraryIds));
+    }
+  }, [isLibraryOpen, existingLibraryIds]);
+
+  const {
+    data: libraryImages = [],
+    isLoading: isLibraryLoading,
+    isError: isLibraryError,
+    error: libraryError,
+    refetch: refetchLibrary,
+  } = useImageLibrary(undefined, { enabled: isLibraryOpen });
 
   const handleFileSelection = (selectedFiles: FileList | null) => {
     if (selectedFiles) {
@@ -49,53 +90,190 @@ export const MultiImageUploader = ({
     handleFileSelection(event.dataTransfer.files);
   };
 
+  const toggleLibrarySelection = (imageId: string) => {
+    setSelectedLibraryIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(imageId)) {
+        next.delete(imageId);
+      } else {
+        next.add(imageId);
+      }
+      return next;
+    });
+  };
+
+  const handleConfirmLibrarySelection = () => {
+    if (!onLibrarySelectionChange) {
+      setIsLibraryOpen(false);
+      return;
+    }
+
+    const selectedImages = libraryImages.filter((image) =>
+      selectedLibraryIds.has(image.id)
+    );
+
+    onLibrarySelectionChange(selectedImages);
+    setIsLibraryOpen(false);
+  };
+
+  const handleLibraryOpenChange = (open: boolean) => {
+    setIsLibraryOpen(open);
+    if (!open) {
+      setSelectedLibraryIds(new Set());
+    }
+  };
+
+  const libraryErrorMessage =
+    libraryError instanceof Error
+      ? libraryError.message
+      : "Không thể tải thư viện hình ảnh.";
+
   return (
-    <div>
+    <div className="space-y-4">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <p className="text-sm text-muted-foreground">
+          Chọn ảnh từ thư viện trước khi tải ảnh mới từ máy của bạn.
+        </p>
+        <Dialog open={isLibraryOpen} onOpenChange={handleLibraryOpenChange}>
+          <DialogTrigger asChild>
+            <Button type="button" variant="outline">
+              <Images className="mr-2 h-4 w-4" />
+              Mở thư viện ảnh
+            </Button>
+          </DialogTrigger>
+          <DialogContent className="sm:max-w-4xl">
+            <DialogHeader>
+              <DialogTitle>Thư viện hình ảnh</DialogTitle>
+              <DialogDescription>
+                Đánh dấu những ảnh bạn muốn sử dụng. Bạn có thể tải thêm ảnh
+                mới sau khi lựa chọn.
+              </DialogDescription>
+            </DialogHeader>
+            <div className="flex flex-col gap-4">
+              {isLibraryLoading ? (
+                <div className="flex h-48 items-center justify-center">
+                  <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+                </div>
+              ) : isLibraryError ? (
+                <div className="flex flex-col items-center gap-3 text-center">
+                  <p className="text-sm text-destructive">{libraryErrorMessage}</p>
+                  <Button onClick={() => refetchLibrary()} variant="outline">
+                    Thử lại
+                  </Button>
+                </div>
+              ) : libraryImages.length === 0 ? (
+                <p className="text-sm text-muted-foreground text-center">
+                  Thư viện hiện chưa có hình ảnh nào.
+                </p>
+              ) : (
+                <ScrollArea className="max-h-[60vh] pr-2">
+                  <div className="grid gap-4 sm:grid-cols-3 md:grid-cols-4">
+                    {libraryImages.map((image) => {
+                      const isSelected = selectedLibraryIds.has(image.id);
+                      return (
+                        <button
+                          key={image.id}
+                          type="button"
+                          onClick={() => toggleLibrarySelection(image.id)}
+                          className={cn(
+                            "relative aspect-square overflow-hidden rounded-md border",
+                            isSelected
+                              ? "border-primary ring-2 ring-primary"
+                              : "border-transparent hover:border-primary"
+                          )}
+                        >
+                          <Image
+                            src={image.url}
+                            alt={image.alt_text ?? "Ảnh trong thư viện"}
+                            fill
+                            className="object-cover"
+                          />
+                          <div
+                            className={cn(
+                              "absolute inset-0 bg-primary/20 opacity-0 transition-opacity",
+                              isSelected && "opacity-100"
+                            )}
+                          />
+                          {isSelected && (
+                            <div className="absolute top-2 right-2 flex h-6 w-6 items-center justify-center rounded-full bg-primary text-primary-foreground">
+                              <Check className="h-4 w-4" />
+                            </div>
+                          )}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </ScrollArea>
+              )}
+            </div>
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => handleLibraryOpenChange(false)}
+              >
+                Đóng
+              </Button>
+              <Button
+                type="button"
+                onClick={handleConfirmLibrarySelection}
+                disabled={onLibrarySelectionChange === undefined}
+              >
+                Sử dụng ảnh đã chọn
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      </div>
+
+      <Separator />
+
       <input
         type="file"
         ref={fileInputRef}
-        onChange={(e) => handleFileSelection(e.target.files)}
+        onChange={(event) => handleFileSelection(event.target.files)}
         className="hidden"
         accept="image/png, image/jpeg, image/gif"
         multiple
       />
+
       <div
         onClick={() => fileInputRef.current?.click()}
         onDragOver={handleDragOver}
         onDragLeave={handleDragLeave}
         onDrop={handleDrop}
         className={cn(
-          "mt-1 border-2 border-dashed border-border rounded-md p-6 flex flex-col items-center justify-center cursor-pointer hover:bg-muted/50 transition-colors",
+          "mt-1 flex cursor-pointer flex-col items-center justify-center rounded-md border-2 border-dashed border-border p-6 transition-colors hover:bg-muted/50",
           isDragging && "border-primary bg-muted/50"
         )}
       >
-        <div className="text-muted-foreground text-center">
-          <UploadCloud className="text-3xl mb-2 mx-auto" />
-          <p>Nhấp hoặc kéo thả ảnh vào đây</p>
+        <div className="text-center text-muted-foreground">
+          <UploadCloud className="mx-auto mb-2 text-3xl" />
+          <p>Nhấp hoặc kéo thả ảnh mới vào đây để tải lên</p>
         </div>
       </div>
 
       {value.length > 0 && (
-        <div className="mt-4 grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
-          {value.map((image) => {
-            // Xác định URL và alt text dựa trên loại đối tượng
+        <div className="grid gap-4 sm:grid-cols-3 md:grid-cols-4">
+          {value.map((image, index) => {
             const imageUrl =
               image instanceof File ? URL.createObjectURL(image) : image.url;
             const altText =
               image instanceof File
                 ? image.name
                 : image.alt_text ?? "Xem trước";
-            // Tạo key duy nhất
-            const key = image instanceof File ? uuidv4() : image.id;
+            const key =
+              image instanceof File
+                ? `file-${index}-${image.name}`
+                : image.id;
 
             return (
-              <div key={key} className="relative group aspect-square">
+              <div key={key} className="group relative aspect-square">
                 <Image
                   src={imageUrl}
                   alt={altText}
                   fill
-                  className="object-cover rounded-md"
-                  // Clean up blob URL khi component unmount để tránh memory leak
+                  className="rounded-md object-cover"
                   onLoad={() => {
                     if (image instanceof File) {
                       URL.revokeObjectURL(imageUrl);
@@ -107,7 +285,7 @@ export const MultiImageUploader = ({
                     type="button"
                     variant="destructive"
                     size="icon"
-                    className="h-6 w-6 opacity-70 group-hover:opacity-100 transition-opacity"
+                    className="h-6 w-6 opacity-70 transition-opacity group-hover:opacity-100"
                     onClick={() => handleRemoveClick(image)}
                   >
                     <X className="h-4 w-4" />

--- a/front-end/src/features/product/components/ProductForm.tsx
+++ b/front-end/src/features/product/components/ProductForm.tsx
@@ -328,10 +328,27 @@ export default function ProductFormFields() {
                   // This is the correct logic to keep
                   field.onChange([...(field.value || []), ...files]);
                 }}
-                onRemoveImage={(imageToRemove) => {
-                  const updatedImages = (field.value || []).filter(
-                    (img) => img !== imageToRemove
+                onLibrarySelectionChange={(selectedImages) => {
+                  const currentFiles = (field.value || []).filter(
+                    (img): img is File => img instanceof File
                   );
+                  field.onChange([...currentFiles, ...selectedImages]);
+                }}
+                onRemoveImage={(imageToRemove) => {
+                  const updatedImages = (field.value || []).filter((img) => {
+                    if (img instanceof File && imageToRemove instanceof File) {
+                      return img !== imageToRemove;
+                    }
+
+                    if (
+                      !(img instanceof File) &&
+                      !(imageToRemove instanceof File)
+                    ) {
+                      return img.id !== imageToRemove.id;
+                    }
+
+                    return true;
+                  });
                   field.onChange(updatedImages);
                 }}
               />

--- a/front-end/src/features/service/components/ServiceForm.tsx
+++ b/front-end/src/features/service/components/ServiceForm.tsx
@@ -262,10 +262,27 @@ export default function ServiceForm() {
                   // Thêm trực tiếp các đối tượng File mới vào state của form
                   field.onChange([...(field.value || []), ...files]);
                 }}
-                onRemoveImage={(imageToRemove) => {
-                  const updatedImages = (field.value || []).filter(
-                    (img) => img !== imageToRemove
+                onLibrarySelectionChange={(selectedImages) => {
+                  const currentFiles = (field.value || []).filter(
+                    (img): img is File => img instanceof File
                   );
+                  field.onChange([...currentFiles, ...selectedImages]);
+                }}
+                onRemoveImage={(imageToRemove) => {
+                  const updatedImages = (field.value || []).filter((img) => {
+                    if (img instanceof File && imageToRemove instanceof File) {
+                      return img !== imageToRemove;
+                    }
+
+                    if (
+                      !(img instanceof File) &&
+                      !(imageToRemove instanceof File)
+                    ) {
+                      return img.id !== imageToRemove.id;
+                    }
+
+                    return true;
+                  });
                   field.onChange(updatedImages);
                 }}
               />

--- a/front-end/src/features/treatment/components/TreatmentPlanForm.tsx
+++ b/front-end/src/features/treatment/components/TreatmentPlanForm.tsx
@@ -302,10 +302,27 @@ export default function TreatmentPlanFormFields() {
                   // === FIX CONFLICT: Giữ lại phiên bản này ===
                   field.onChange([...(field.value || []), ...files]);
                 }}
-                onRemoveImage={(imageToRemove) => {
-                  const updatedImages = (field.value || []).filter(
-                    (img) => img !== imageToRemove
+                onLibrarySelectionChange={(selectedImages) => {
+                  const currentFiles = (field.value || []).filter(
+                    (img): img is File => img instanceof File
                   );
+                  field.onChange([...currentFiles, ...selectedImages]);
+                }}
+                onRemoveImage={(imageToRemove) => {
+                  const updatedImages = (field.value || []).filter((img) => {
+                    if (img instanceof File && imageToRemove instanceof File) {
+                      return img !== imageToRemove;
+                    }
+
+                    if (
+                      !(img instanceof File) &&
+                      !(imageToRemove instanceof File)
+                    ) {
+                      return img.id !== imageToRemove.id;
+                    }
+
+                    return true;
+                  });
                   field.onChange(updatedImages);
                 }}
               />

--- a/front-end/src/features/upload/hooks/useImageLibrary.ts
+++ b/front-end/src/features/upload/hooks/useImageLibrary.ts
@@ -1,0 +1,30 @@
+"use client";
+
+import { ImageUrl } from "@/features/shared/types";
+import { useQuery } from "@tanstack/react-query";
+
+import {
+  FetchImageLibraryParams,
+  fetchImageLibrary,
+} from "../upload.api";
+
+type UseImageLibraryOptions = {
+  enabled?: boolean;
+};
+
+/**
+ * Hook tiện ích để lấy danh sách hình ảnh trong thư viện dùng chung.
+ */
+export function useImageLibrary(
+  params?: FetchImageLibraryParams,
+  options: UseImageLibraryOptions = {}
+) {
+  return useQuery<ImageUrl[]>({
+    queryKey: ["image-library", params],
+    queryFn: () => fetchImageLibrary(params),
+    staleTime: 1000 * 60 * 5,
+    gcTime: 1000 * 60 * 30,
+    enabled: options.enabled ?? true,
+  });
+}
+

--- a/front-end/src/features/upload/upload.api.ts
+++ b/front-end/src/features/upload/upload.api.ts
@@ -1,5 +1,7 @@
 // src/features/upload/upload.api.ts
 import { ImageUrl } from "@/features/shared/types";
+import apiClient from "@/lib/apiClient";
+import { buildQueryString } from "@/lib/queryString";
 
 // Endpoint mới cho dịch vụ upload hình ảnh dùng chung
 const UPLOAD_ENDPOINT = "/images";
@@ -10,6 +12,28 @@ type UploadImageOptions = {
   serviceIds?: string[];
   treatmentPlanIds?: string[];
 };
+
+export type FetchImageLibraryParams = {
+  productId?: string;
+  serviceId?: string;
+  treatmentPlanId?: string;
+};
+
+/**
+ * Lấy danh sách hình ảnh đã được tải lên từ thư viện chung.
+ * @param params Các tham số lọc theo loại đối tượng liên kết.
+ */
+export async function fetchImageLibrary(
+  params?: FetchImageLibraryParams
+): Promise<ImageUrl[]> {
+  const query = buildQueryString({
+    product_id: params?.productId,
+    service_id: params?.serviceId,
+    treatment_plan_id: params?.treatmentPlanId,
+  });
+
+  return apiClient<ImageUrl[]>(`${UPLOAD_ENDPOINT}${query}`);
+}
 
 /**
  * Tải một file lên server.


### PR DESCRIPTION
## Summary
- add an API helper and React Query hook for loading the shared media library
- enhance the multi-image uploader to open the image library dialog before uploading new files
- update product, service, and treatment forms to sync library selections with form state

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e38f58281883289e0f227d7993dab8