### PR TITLE
Refactor product image handling for many-to-many support

### DIFF
--- a/back-end/app/models/products_model.py
+++ b/back-end/app/models/products_model.py
@@ -1,11 +1,16 @@
-# app/models/products_model.py
-import uuid
-from typing import List, Optional, TYPE_CHECKING
-from sqlmodel import Field, Relationship
-from app.models.base_model import BaseUUIDModel
-from app.models.association_tables import ProductCategoryLink, ProductImageLink
+"""Định nghĩa mô hình ``Product`` cùng quan hệ nhiều-nhiều với hình ảnh."""
 
-if TYPE_CHECKING:
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING, List, Optional
+
+from sqlmodel import Field, Relationship
+
+from app.models.association_tables import ProductCategoryLink, ProductImageLink
+from app.models.base_model import BaseUUIDModel
+
+if TYPE_CHECKING:  # pragma: no cover - chỉ dùng cho gợi ý kiểu
     from app.models.catalog_model import Category, Image
 
 
@@ -22,10 +27,14 @@ class Product(BaseUUIDModel, table=True):
     conversion_rate: Optional[float] = Field(default=None, gt=0)  # Tỷ lệ quy đổi
 
     categories: List["Category"] = Relationship(
-        back_populates="products", link_model=ProductCategoryLink
+        back_populates="products",
+        link_model=ProductCategoryLink,
+        sa_relationship_kwargs={"lazy": "selectin"},
     )
     images: List["Image"] = Relationship(
-        back_populates="products", link_model=ProductImageLink
+        back_populates="products",
+        link_model=ProductImageLink,
+        sa_relationship_kwargs={"lazy": "selectin"},
     )
     primary_image_id: Optional[uuid.UUID] = Field(
         default=None, foreign_key="image.id", nullable=True
@@ -36,3 +45,6 @@ class Product(BaseUUIDModel, table=True):
             "foreign_keys": "Product.primary_image_id",
         }
     )
+
+    def __repr__(self) -> str:  # pragma: no cover - dùng cho debug/log
+        return f"Product(id={self.id!s}, name={self.name!r})"


### PR DESCRIPTION
## Summary
- refine the Product model to optimise many-to-many relations with categories and images
- tighten product schemas with validators for category and image payloads
- refactor the product service to share image-sync logic and enforce unique naming

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68e39f047bdc83289284ad07b40cb28d