### PR TITLE
Refactor image management and associations

### DIFF
--- a/back-end/alembic/versions/0d3374933ea8_init.py
+++ b/back-end/alembic/versions/0d3374933ea8_init.py
@@ -1,8 +1,8 @@
 """init
 
-Revision ID: 2df69e15f2a7
+Revision ID: 0d3374933ea8
 Revises:
-Create Date: 2025-10-05 20:51:41.789519
+Create Date: 2025-10-07 19:03:43.797964
 
 """
 
@@ -12,9 +12,8 @@ from alembic import op
 import sqlalchemy as sa
 import sqlmodel
 
-
 # revision identifiers, used by Alembic.
-revision: str = "2df69e15f2a7"
+revision: str = "0d3374933ea8"
 down_revision: Union[str, Sequence[str], None] = None
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
@@ -46,6 +45,22 @@ def upgrade() -> None:
         op.f("ix_category_is_deleted"), "category", ["is_deleted"], unique=False
     )
     op.create_index(op.f("ix_category_name"), "category", ["name"], unique=False)
+    op.create_table(
+        "image",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column(
+            "created_at", sa.DateTime(), server_default=sa.text("now()"), nullable=False
+        ),
+        sa.Column(
+            "updated_at", sa.DateTime(), server_default=sa.text("now()"), nullable=False
+        ),
+        sa.Column("is_deleted", sa.Boolean(), nullable=False),
+        sa.Column("url", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.Column("alt_text", sqlmodel.sql.sqltypes.AutoString(), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_image_id"), "image", ["id"], unique=False)
+    op.create_index(op.f("ix_image_is_deleted"), "image", ["is_deleted"], unique=False)
     op.create_table(
         "permission",
         sa.Column("id", sa.Uuid(), nullable=False),
@@ -107,150 +122,6 @@ def upgrade() -> None:
     op.create_index(op.f("ix_user_id"), "user", ["id"], unique=False)
     op.create_index(op.f("ix_user_is_deleted"), "user", ["is_deleted"], unique=False)
     op.create_index(op.f("ix_user_phone"), "user", ["phone"], unique=True)
-
-    # Bảng service, product, treatment_plan phải được tạo trước image
-    op.create_table(
-        "service",
-        sa.Column("id", sa.Uuid(), nullable=False),
-        sa.Column(
-            "created_at", sa.DateTime(), server_default=sa.text("now()"), nullable=False
-        ),
-        sa.Column(
-            "updated_at", sa.DateTime(), server_default=sa.text("now()"), nullable=False
-        ),
-        sa.Column("is_deleted", sa.Boolean(), nullable=False),
-        sa.Column("name", sqlmodel.sql.sqltypes.AutoString(length=100), nullable=False),
-        sa.Column("description", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
-        sa.Column("price", sa.Float(), nullable=False),
-        sa.Column("duration_minutes", sa.Integer(), nullable=False),
-        sa.Column(
-            "preparation_notes", sqlmodel.sql.sqltypes.AutoString(), nullable=True
-        ),
-        sa.Column(
-            "aftercare_instructions", sqlmodel.sql.sqltypes.AutoString(), nullable=True
-        ),
-        sa.Column(
-            "contraindications", sqlmodel.sql.sqltypes.AutoString(), nullable=True
-        ),
-        sa.Column("primary_image_id", sa.Uuid(), nullable=True),
-        # Di chuyển foreign key ra sau khi tạo bảng image
-        sa.PrimaryKeyConstraint("id"),
-    )
-    op.create_index(op.f("ix_service_id"), "service", ["id"], unique=False)
-    op.create_index(
-        op.f("ix_service_is_deleted"), "service", ["is_deleted"], unique=False
-    )
-    op.create_index(op.f("ix_service_name"), "service", ["name"], unique=True)
-
-    op.create_table(
-        "product",
-        sa.Column("id", sa.Uuid(), nullable=False),
-        sa.Column(
-            "created_at", sa.DateTime(), server_default=sa.text("now()"), nullable=False
-        ),
-        sa.Column(
-            "updated_at", sa.DateTime(), server_default=sa.text("now()"), nullable=False
-        ),
-        sa.Column("is_deleted", sa.Boolean(), nullable=False),
-        sa.Column("name", sqlmodel.sql.sqltypes.AutoString(length=100), nullable=False),
-        sa.Column("description", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
-        sa.Column("price", sa.Float(), nullable=False),
-        sa.Column("stock", sa.Integer(), nullable=False),
-        sa.Column("is_retail", sa.Boolean(), nullable=False),
-        sa.Column("is_consumable", sa.Boolean(), nullable=False),
-        sa.Column(
-            "base_unit", sqlmodel.sql.sqltypes.AutoString(length=50), nullable=False
-        ),
-        sa.Column(
-            "consumable_unit",
-            sqlmodel.sql.sqltypes.AutoString(length=50),
-            nullable=True,
-        ),
-        sa.Column("conversion_rate", sa.Float(), nullable=True),
-        sa.Column("primary_image_id", sa.Uuid(), nullable=True),
-        # Di chuyển foreign key ra sau khi tạo bảng image
-        sa.PrimaryKeyConstraint("id"),
-    )
-    op.create_index(op.f("ix_product_id"), "product", ["id"], unique=False)
-    op.create_index(
-        op.f("ix_product_is_deleted"), "product", ["is_deleted"], unique=False
-    )
-    op.create_index(op.f("ix_product_name"), "product", ["name"], unique=True)
-
-    op.create_table(
-        "treatment_plan",
-        sa.Column("id", sa.Uuid(), nullable=False),
-        sa.Column(
-            "created_at", sa.DateTime(), server_default=sa.text("now()"), nullable=False
-        ),
-        sa.Column(
-            "updated_at", sa.DateTime(), server_default=sa.text("now()"), nullable=False
-        ),
-        sa.Column("is_deleted", sa.Boolean(), nullable=False),
-        sa.Column("name", sqlmodel.sql.sqltypes.AutoString(length=100), nullable=False),
-        sa.Column("description", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
-        sa.Column("price", sa.Float(), nullable=False),
-        sa.Column("total_sessions", sa.Integer(), nullable=False),
-        sa.Column("category_id", sa.Uuid(), nullable=False),
-        sa.Column("primary_image_id", sa.Uuid(), nullable=True),
-        sa.ForeignKeyConstraint(
-            ["category_id"],
-            ["category.id"],
-        ),
-        # Di chuyển foreign key ra sau khi tạo bảng image
-        sa.PrimaryKeyConstraint("id"),
-    )
-    op.create_index(
-        op.f("ix_treatment_plan_id"), "treatment_plan", ["id"], unique=False
-    )
-    op.create_index(
-        op.f("ix_treatment_plan_is_deleted"),
-        "treatment_plan",
-        ["is_deleted"],
-        unique=False,
-    )
-    op.create_index(
-        op.f("ix_treatment_plan_name"), "treatment_plan", ["name"], unique=True
-    )
-
-    # Bây giờ tạo bảng image
-    op.create_table(
-        "image",
-        sa.Column("id", sa.Uuid(), nullable=False),
-        sa.Column(
-            "created_at", sa.DateTime(), server_default=sa.text("now()"), nullable=False
-        ),
-        sa.Column(
-            "updated_at", sa.DateTime(), server_default=sa.text("now()"), nullable=False
-        ),
-        sa.Column("is_deleted", sa.Boolean(), nullable=False),
-        sa.Column("url", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
-        sa.Column("alt_text", sqlmodel.sql.sqltypes.AutoString(), nullable=True),
-        sa.Column("service_id", sa.Uuid(), nullable=True),
-        sa.Column("product_id", sa.Uuid(), nullable=True),
-        sa.Column("treatment_plan_id", sa.Uuid(), nullable=True),
-        sa.ForeignKeyConstraint(
-            ["product_id"],
-            ["product.id"],
-        ),
-        sa.ForeignKeyConstraint(
-            ["service_id"],
-            ["service.id"],
-        ),
-        sa.ForeignKeyConstraint(
-            ["treatment_plan_id"],
-            ["treatment_plan.id"],
-        ),
-        sa.PrimaryKeyConstraint("id"),
-    )
-    op.create_index(op.f("ix_image_id"), "image", ["id"], unique=False)
-    op.create_index(op.f("ix_image_is_deleted"), "image", ["is_deleted"], unique=False)
-
-    # Thêm các khóa ngoại đã di chuyển ở trên
-    op.create_foreign_key(None, "service", "image", ["primary_image_id"], ["id"])
-    op.create_foreign_key(None, "product", "image", ["primary_image_id"], ["id"])
-    op.create_foreign_key(None, "treatment_plan", "image", ["primary_image_id"], ["id"])
-    # Các bảng còn lại
     op.create_table(
         "default_schedule",
         sa.Column("id", sa.Uuid(), nullable=False),
@@ -288,19 +159,42 @@ def upgrade() -> None:
         unique=False,
     )
     op.create_table(
-        "product_category_link",
-        sa.Column("product_id", sa.Uuid(), nullable=False),
-        sa.Column("category_id", sa.Uuid(), nullable=False),
-        sa.ForeignKeyConstraint(
-            ["category_id"],
-            ["category.id"],
+        "product",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column(
+            "created_at", sa.DateTime(), server_default=sa.text("now()"), nullable=False
         ),
-        sa.ForeignKeyConstraint(
-            ["product_id"],
-            ["product.id"],
+        sa.Column(
+            "updated_at", sa.DateTime(), server_default=sa.text("now()"), nullable=False
         ),
-        sa.PrimaryKeyConstraint("product_id", "category_id"),
+        sa.Column("is_deleted", sa.Boolean(), nullable=False),
+        sa.Column("name", sqlmodel.sql.sqltypes.AutoString(length=100), nullable=False),
+        sa.Column("description", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.Column("price", sa.Float(), nullable=False),
+        sa.Column("stock", sa.Integer(), nullable=False),
+        sa.Column("is_retail", sa.Boolean(), nullable=False),
+        sa.Column("is_consumable", sa.Boolean(), nullable=False),
+        sa.Column(
+            "base_unit", sqlmodel.sql.sqltypes.AutoString(length=50), nullable=False
+        ),
+        sa.Column(
+            "consumable_unit",
+            sqlmodel.sql.sqltypes.AutoString(length=50),
+            nullable=True,
+        ),
+        sa.Column("conversion_rate", sa.Float(), nullable=True),
+        sa.Column("primary_image_id", sa.Uuid(), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["primary_image_id"],
+            ["image.id"],
+        ),
+        sa.PrimaryKeyConstraint("id"),
     )
+    op.create_index(op.f("ix_product_id"), "product", ["id"], unique=False)
+    op.create_index(
+        op.f("ix_product_is_deleted"), "product", ["is_deleted"], unique=False
+    )
+    op.create_index(op.f("ix_product_name"), "product", ["name"], unique=True)
     op.create_table(
         "role_permission",
         sa.Column("role_id", sa.Uuid(), nullable=False),
@@ -316,6 +210,121 @@ def upgrade() -> None:
         sa.PrimaryKeyConstraint("role_id", "permission_id"),
     )
     op.create_table(
+        "service",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column(
+            "created_at", sa.DateTime(), server_default=sa.text("now()"), nullable=False
+        ),
+        sa.Column(
+            "updated_at", sa.DateTime(), server_default=sa.text("now()"), nullable=False
+        ),
+        sa.Column("is_deleted", sa.Boolean(), nullable=False),
+        sa.Column("name", sqlmodel.sql.sqltypes.AutoString(length=100), nullable=False),
+        sa.Column("description", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.Column("price", sa.Float(), nullable=False),
+        sa.Column("duration_minutes", sa.Integer(), nullable=False),
+        sa.Column(
+            "preparation_notes", sqlmodel.sql.sqltypes.AutoString(), nullable=True
+        ),
+        sa.Column(
+            "aftercare_instructions", sqlmodel.sql.sqltypes.AutoString(), nullable=True
+        ),
+        sa.Column(
+            "contraindications", sqlmodel.sql.sqltypes.AutoString(), nullable=True
+        ),
+        sa.Column("primary_image_id", sa.Uuid(), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["primary_image_id"],
+            ["image.id"],
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(op.f("ix_service_id"), "service", ["id"], unique=False)
+    op.create_index(
+        op.f("ix_service_is_deleted"), "service", ["is_deleted"], unique=False
+    )
+    op.create_index(op.f("ix_service_name"), "service", ["name"], unique=True)
+    op.create_table(
+        "treatment_plan",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column(
+            "created_at", sa.DateTime(), server_default=sa.text("now()"), nullable=False
+        ),
+        sa.Column(
+            "updated_at", sa.DateTime(), server_default=sa.text("now()"), nullable=False
+        ),
+        sa.Column("is_deleted", sa.Boolean(), nullable=False),
+        sa.Column("name", sqlmodel.sql.sqltypes.AutoString(length=100), nullable=False),
+        sa.Column("description", sqlmodel.sql.sqltypes.AutoString(), nullable=False),
+        sa.Column("price", sa.Float(), nullable=False),
+        sa.Column("total_sessions", sa.Integer(), nullable=False),
+        sa.Column("category_id", sa.Uuid(), nullable=False),
+        sa.Column("primary_image_id", sa.Uuid(), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["category_id"],
+            ["category.id"],
+        ),
+        sa.ForeignKeyConstraint(
+            ["primary_image_id"],
+            ["image.id"],
+        ),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        op.f("ix_treatment_plan_id"), "treatment_plan", ["id"], unique=False
+    )
+    op.create_index(
+        op.f("ix_treatment_plan_is_deleted"),
+        "treatment_plan",
+        ["is_deleted"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_treatment_plan_name"), "treatment_plan", ["name"], unique=True
+    )
+    op.create_table(
+        "user_role",
+        sa.Column("user_id", sa.Uuid(), nullable=False),
+        sa.Column("role_id", sa.Uuid(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["role_id"],
+            ["role.id"],
+        ),
+        sa.ForeignKeyConstraint(
+            ["user_id"],
+            ["user.id"],
+        ),
+        sa.PrimaryKeyConstraint("user_id", "role_id"),
+    )
+    op.create_table(
+        "product_category_link",
+        sa.Column("product_id", sa.Uuid(), nullable=False),
+        sa.Column("category_id", sa.Uuid(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["category_id"],
+            ["category.id"],
+        ),
+        sa.ForeignKeyConstraint(
+            ["product_id"],
+            ["product.id"],
+        ),
+        sa.PrimaryKeyConstraint("product_id", "category_id"),
+    )
+    op.create_table(
+        "product_image_link",
+        sa.Column("product_id", sa.Uuid(), nullable=False),
+        sa.Column("image_id", sa.Uuid(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["image_id"],
+            ["image.id"],
+        ),
+        sa.ForeignKeyConstraint(
+            ["product_id"],
+            ["product.id"],
+        ),
+        sa.PrimaryKeyConstraint("product_id", "image_id"),
+    )
+    op.create_table(
         "service_category_link",
         sa.Column("service_id", sa.Uuid(), nullable=False),
         sa.Column("category_id", sa.Uuid(), nullable=False),
@@ -328,6 +337,34 @@ def upgrade() -> None:
             ["service.id"],
         ),
         sa.PrimaryKeyConstraint("service_id", "category_id"),
+    )
+    op.create_table(
+        "service_image_link",
+        sa.Column("service_id", sa.Uuid(), nullable=False),
+        sa.Column("image_id", sa.Uuid(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["image_id"],
+            ["image.id"],
+        ),
+        sa.ForeignKeyConstraint(
+            ["service_id"],
+            ["service.id"],
+        ),
+        sa.PrimaryKeyConstraint("service_id", "image_id"),
+    )
+    op.create_table(
+        "treatment_plan_image_link",
+        sa.Column("treatment_plan_id", sa.Uuid(), nullable=False),
+        sa.Column("image_id", sa.Uuid(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["image_id"],
+            ["image.id"],
+        ),
+        sa.ForeignKeyConstraint(
+            ["treatment_plan_id"],
+            ["treatment_plan.id"],
+        ),
+        sa.PrimaryKeyConstraint("treatment_plan_id", "image_id"),
     )
     op.create_table(
         "treatment_plan_step",
@@ -362,35 +399,36 @@ def upgrade() -> None:
         ["is_deleted"],
         unique=False,
     )
-    op.create_table(
-        "user_role",
-        sa.Column("user_id", sa.Uuid(), nullable=False),
-        sa.Column("role_id", sa.Uuid(), nullable=False),
-        sa.ForeignKeyConstraint(
-            ["role_id"],
-            ["role.id"],
-        ),
-        sa.ForeignKeyConstraint(
-            ["user_id"],
-            ["user.id"],
-        ),
-        sa.PrimaryKeyConstraint("user_id", "role_id"),
-    )
     # ### end Alembic commands ###
 
 
 def downgrade() -> None:
     """Downgrade schema."""
     # ### commands auto generated by Alembic - please adjust! ###
-    op.drop_table("user_role")
     op.drop_index(
         op.f("ix_treatment_plan_step_is_deleted"), table_name="treatment_plan_step"
     )
     op.drop_index(op.f("ix_treatment_plan_step_id"), table_name="treatment_plan_step")
     op.drop_table("treatment_plan_step")
+    op.drop_table("treatment_plan_image_link")
+    op.drop_table("service_image_link")
     op.drop_table("service_category_link")
-    op.drop_table("role_permission")
+    op.drop_table("product_image_link")
     op.drop_table("product_category_link")
+    op.drop_table("user_role")
+    op.drop_index(op.f("ix_treatment_plan_name"), table_name="treatment_plan")
+    op.drop_index(op.f("ix_treatment_plan_is_deleted"), table_name="treatment_plan")
+    op.drop_index(op.f("ix_treatment_plan_id"), table_name="treatment_plan")
+    op.drop_table("treatment_plan")
+    op.drop_index(op.f("ix_service_name"), table_name="service")
+    op.drop_index(op.f("ix_service_is_deleted"), table_name="service")
+    op.drop_index(op.f("ix_service_id"), table_name="service")
+    op.drop_table("service")
+    op.drop_table("role_permission")
+    op.drop_index(op.f("ix_product_name"), table_name="product")
+    op.drop_index(op.f("ix_product_is_deleted"), table_name="product")
+    op.drop_index(op.f("ix_product_id"), table_name="product")
+    op.drop_table("product")
     op.drop_index(op.f("ix_default_schedule_user_id"), table_name="default_schedule")
     op.drop_index(op.f("ix_default_schedule_is_deleted"), table_name="default_schedule")
     op.drop_index(op.f("ix_default_schedule_id"), table_name="default_schedule")
@@ -400,22 +438,10 @@ def downgrade() -> None:
     op.drop_index(op.f("ix_user_id"), table_name="user")
     op.drop_index(op.f("ix_user_email"), table_name="user")
     op.drop_table("user")
-    op.drop_index(op.f("ix_treatment_plan_name"), table_name="treatment_plan")
-    op.drop_index(op.f("ix_treatment_plan_is_deleted"), table_name="treatment_plan")
-    op.drop_index(op.f("ix_treatment_plan_id"), table_name="treatment_plan")
-    op.drop_table("treatment_plan")
-    op.drop_index(op.f("ix_service_name"), table_name="service")
-    op.drop_index(op.f("ix_service_is_deleted"), table_name="service")
-    op.drop_index(op.f("ix_service_id"), table_name="service")
-    op.drop_table("service")
     op.drop_index(op.f("ix_role_name"), table_name="role")
     op.drop_index(op.f("ix_role_is_deleted"), table_name="role")
     op.drop_index(op.f("ix_role_id"), table_name="role")
     op.drop_table("role")
-    op.drop_index(op.f("ix_product_name"), table_name="product")
-    op.drop_index(op.f("ix_product_is_deleted"), table_name="product")
-    op.drop_index(op.f("ix_product_id"), table_name="product")
-    op.drop_table("product")
     op.drop_index(op.f("ix_permission_name"), table_name="permission")
     op.drop_index(op.f("ix_permission_is_deleted"), table_name="permission")
     op.drop_index(op.f("ix_permission_id"), table_name="permission")

--- a/back-end/app/models/association_tables.py
+++ b/back-end/app/models/association_tables.py
@@ -25,3 +25,28 @@ class ProductCategoryLink(SQLModel, table=True):
         foreign_key="category.id",
         primary_key=True,
     )
+
+
+# =================================================================
+# BẢNG LIÊN KẾT HÌNH ẢNH (MỚI)
+# =================================================================
+
+
+class ProductImageLink(SQLModel, table=True):
+    __tablename__ = "product_image_link"
+    product_id: uuid.UUID = Field(foreign_key="product.id", primary_key=True)
+    image_id: uuid.UUID = Field(foreign_key="image.id", primary_key=True)
+
+
+class ServiceImageLink(SQLModel, table=True):
+    __tablename__ = "service_image_link"
+    service_id: uuid.UUID = Field(foreign_key="service.id", primary_key=True)
+    image_id: uuid.UUID = Field(foreign_key="image.id", primary_key=True)
+
+
+class TreatmentPlanImageLink(SQLModel, table=True):
+    __tablename__ = "treatment_plan_image_link"
+    treatment_plan_id: uuid.UUID = Field(
+        foreign_key="treatment_plan.id", primary_key=True
+    )
+    image_id: uuid.UUID = Field(foreign_key="image.id", primary_key=True)

--- a/back-end/app/models/catalog_model.py
+++ b/back-end/app/models/catalog_model.py
@@ -5,7 +5,13 @@ from sqlmodel import SQLModel, Field, Relationship
 from app.models.base_model import BaseUUIDModel
 
 # Import bảng liên kết mới
-from app.models.association_tables import ProductCategoryLink, ServiceCategoryLink
+from app.models.association_tables import (
+    ProductCategoryLink,
+    ProductImageLink,
+    ServiceCategoryLink,
+    ServiceImageLink,
+    TreatmentPlanImageLink,
+)
 
 if TYPE_CHECKING:
     from app.models.services_model import Service
@@ -35,21 +41,12 @@ class Image(BaseUUIDModel, table=True):
     __tablename__ = "image"
     url: str = Field(nullable=False)
     alt_text: Optional[str] = Field(default=None)
-    service_id: Optional[uuid.UUID] = Field(default=None, foreign_key="service.id")
-    product_id: Optional[uuid.UUID] = Field(default=None, foreign_key="product.id")
-    treatment_plan_id: Optional[uuid.UUID] = Field(
-        default=None, foreign_key="treatment_plan.id"
+    products: List["Product"] = Relationship(
+        back_populates="images", link_model=ProductImageLink
     )
-    service: Optional["Service"] = Relationship(
-        back_populates="images",
-        sa_relationship_kwargs={"foreign_keys": "Image.service_id"},
+    services: List["Service"] = Relationship(
+        back_populates="images", link_model=ServiceImageLink
     )
-    product: Optional["Product"] = Relationship(
-        back_populates="images",
-        sa_relationship_kwargs={"foreign_keys": "Image.product_id"},
+    treatment_plans: List["TreatmentPlan"] = Relationship(
+        back_populates="images", link_model=TreatmentPlanImageLink
     )
-    treatment_plan: Optional["TreatmentPlan"] = Relationship(
-        back_populates="images",
-        sa_relationship_kwargs={"foreign_keys": "Image.treatment_plan_id"},
-    )
-

--- a/back-end/app/models/products_model.py
+++ b/back-end/app/models/products_model.py
@@ -3,7 +3,7 @@ import uuid
 from typing import List, Optional, TYPE_CHECKING
 from sqlmodel import Field, Relationship
 from app.models.base_model import BaseUUIDModel
-from app.models.association_tables import ProductCategoryLink
+from app.models.association_tables import ProductCategoryLink, ProductImageLink
 
 if TYPE_CHECKING:
     from app.models.catalog_model import Category, Image
@@ -25,8 +25,7 @@ class Product(BaseUUIDModel, table=True):
         back_populates="products", link_model=ProductCategoryLink
     )
     images: List["Image"] = Relationship(
-        back_populates="product",
-        sa_relationship_kwargs={"foreign_keys": "Image.product_id"},
+        back_populates="products", link_model=ProductImageLink
     )
     primary_image_id: Optional[uuid.UUID] = Field(
         default=None, foreign_key="image.id", nullable=True

--- a/back-end/app/models/services_model.py
+++ b/back-end/app/models/services_model.py
@@ -5,7 +5,7 @@ from sqlmodel import Field, Relationship
 from app.models.base_model import BaseUUIDModel
 
 # Import bảng liên kết mới
-from app.models.association_tables import ServiceCategoryLink
+from app.models.association_tables import ServiceCategoryLink, ServiceImageLink
 
 if TYPE_CHECKING:
     from app.models.catalog_model import Category, Image
@@ -39,8 +39,7 @@ class Service(BaseUUIDModel, table=True):
     )
 
     images: List["Image"] = Relationship(
-        back_populates="service",
-        sa_relationship_kwargs={"foreign_keys": "Image.service_id"},
+        back_populates="services", link_model=ServiceImageLink
     )
     primary_image_id: Optional[uuid.UUID] = Field(
         default=None, foreign_key="image.id", nullable=True
@@ -56,6 +55,4 @@ class Service(BaseUUIDModel, table=True):
     def category_ids(self) -> List[uuid.UUID]:
         """Danh sách ID của các danh mục không bị xóa mềm."""
 
-        return [
-            category.id for category in self.categories if not category.is_deleted
-        ]
+        return [category.id for category in self.categories if not category.is_deleted]

--- a/back-end/app/models/treatment_plans_model.py
+++ b/back-end/app/models/treatment_plans_model.py
@@ -3,6 +3,7 @@ import uuid
 from typing import List, Optional, TYPE_CHECKING
 from sqlmodel import Field, Relationship
 from app.models.base_model import BaseUUIDModel
+from app.models.association_tables import TreatmentPlanImageLink
 
 if TYPE_CHECKING:
     from app.models.catalog_model import Category, Image
@@ -31,8 +32,7 @@ class TreatmentPlan(BaseUUIDModel, table=True):
     category_id: uuid.UUID = Field(foreign_key="category.id")
     category: "Category" = Relationship(back_populates="treatment_plans")
     images: List["Image"] = Relationship(
-        back_populates="treatment_plan",
-        sa_relationship_kwargs={"foreign_keys": "Image.treatment_plan_id"},
+        back_populates="treatment_plans", link_model=TreatmentPlanImageLink
     )
     primary_image_id: Optional[uuid.UUID] = Field(
         default=None, foreign_key="image.id", nullable=True

--- a/back-end/app/services/products_service.py
+++ b/back-end/app/services/products_service.py
@@ -13,7 +13,7 @@ from app.models.products_model import Product
 from app.schemas.catalog_schema import CategoryTypeEnum
 from app.schemas.products_schema import ProductCreate, ProductUpdate
 from app.services import catalog_service
-from app.services.images_service import sync_entity_images
+from app.services.images_service import sync_images_for_entity
 
 
 def _with_product_relationships(statement):
@@ -108,10 +108,10 @@ async def create_product(
     db.commit()
     db.refresh(db_product)
 
-    await sync_entity_images(
+    await sync_images_for_entity(
         db,
         entity=db_product,
-        owner="product",
+        owner_type="product",
         new_images=new_images,
         existing_image_ids=(
             existing_image_ids
@@ -135,10 +135,7 @@ def get_all_products(db: Session, skip: int = 0, limit: int = 100) -> List[Produ
     """Lấy danh sách sản phẩm chưa bị xóa mềm."""
 
     statement = _with_product_relationships(
-        select(Product)
-        .where(Product.is_deleted == False)
-        .offset(skip)
-        .limit(limit)
+        select(Product).where(Product.is_deleted == False).offset(skip).limit(limit)
     )
     products = db.exec(statement).unique().all()
     return [_filter_soft_deleted_relationships(product) for product in products]
@@ -203,10 +200,10 @@ async def update_product(
     db.add(db_product)
     db.flush()
 
-    await sync_entity_images(
+    await sync_images_for_entity(
         db,
         entity=db_product,
-        owner="product",
+        owner_type="product",
         new_images=new_images,
         existing_image_ids=(
             existing_image_ids

--- a/back-end/app/services/services_service.py
+++ b/back-end/app/services/services_service.py
@@ -11,7 +11,7 @@ from app.models.services_model import Service
 from app.schemas.catalog_schema import CategoryTypeEnum
 from app.schemas.services_schema import ServiceCreate, ServiceUpdate
 from app.services import catalog_service
-from app.services.images_service import sync_entity_images
+from app.services.images_service import sync_images_for_entity
 
 
 def _filter_soft_deleted_relationships(service: Service) -> Service:
@@ -78,10 +78,10 @@ async def create_service(
     db.commit()
     db.refresh(db_service)
 
-    await sync_entity_images(
+    await sync_images_for_entity(
         db,
         entity=db_service,
-        owner="service",
+        owner_type="service",
         new_images=images,
         existing_image_ids=service_in.existing_image_ids,
         primary_image_id=service_in.primary_image_id,
@@ -130,10 +130,10 @@ async def update_service(
     db.add(db_service)
     db.flush()
 
-    await sync_entity_images(
+    await sync_images_for_entity(
         db,
         entity=db_service,
-        owner="service",
+        owner_type="service",
         new_images=new_images,
         existing_image_ids=(
             existing_image_ids

--- a/back-end/app/services/treatment_plans_service.py
+++ b/back-end/app/services/treatment_plans_service.py
@@ -15,7 +15,7 @@ from app.schemas.treatment_plans_schema import (
     TreatmentPlanUpdate,
 )
 from app.services import catalog_service, services_service
-from app.services.images_service import sync_entity_images
+from app.services.images_service import sync_images_for_entity
 
 
 def _with_treatment_plan_relationships(statement):
@@ -56,7 +56,9 @@ def _filter_soft_deleted_relationships(
             continue
         if step.service:
             step.service.categories = [
-                category for category in step.service.categories if not category.is_deleted
+                category
+                for category in step.service.categories
+                if not category.is_deleted
             ]
         filtered_steps.append(step)
     treatment_plan.steps = filtered_steps
@@ -100,10 +102,10 @@ async def create_treatment_plan(
         )
         db.add(db_step)
 
-    await sync_entity_images(
+    await sync_images_for_entity(
         db,
         entity=db_plan,
-        owner="treatment_plan",
+        owner_type="treatment_plan",
         existing_image_ids=treatment_plan_in.existing_image_ids,
         primary_image_id=treatment_plan_in.primary_image_id,
         alt_text=db_plan.name,
@@ -180,10 +182,10 @@ async def update_treatment_plan(
     db.add(db_treatment_plan)
     db.flush()
 
-    await sync_entity_images(
+    await sync_images_for_entity(
         db,
         entity=db_treatment_plan,
-        owner="treatment_plan",
+        owner_type="treatment_plan",
         existing_image_ids=treatment_plan_in.existing_image_ids,
         primary_image_id=treatment_plan_in.primary_image_id,
         alt_text=db_treatment_plan.name,
@@ -193,7 +195,9 @@ async def update_treatment_plan(
     return get_treatment_plan_by_id(db, db_treatment_plan.id)
 
 
-def delete_treatment_plan(db: Session, db_treatment_plan: TreatmentPlan) -> TreatmentPlan:
+def delete_treatment_plan(
+    db: Session, db_treatment_plan: TreatmentPlan
+) -> TreatmentPlan:
     db_treatment_plan.is_deleted = True
     db.add(db_treatment_plan)
     db.commit()

--- a/front-end/src/features/treatment/api/treatment.api.ts
+++ b/front-end/src/features/treatment/api/treatment.api.ts
@@ -1,10 +1,10 @@
 // src/features/treatment/api/treatment.api.ts
+import { ImageUrl } from "@/features/shared/types";
+import { TreatmentPlanFormValues } from "@/features/treatment/schemas";
 import { TreatmentPlan } from "@/features/treatment/types";
+import { uploadFile } from "@/features/upload/upload.api";
 import apiClient from "@/lib/apiClient";
 import { buildQueryString } from "@/lib/queryString";
-import { TreatmentPlanFormValues } from "@/features/treatment/schemas";
-import { ImageUrl } from "@/features/shared/types";
-import { uploadFile } from "@/features/upload/upload.api";
 
 /**
  * Xử lý upload các file mới và trả về danh sách ImageUrl hoàn chỉnh.


### PR DESCRIPTION
- Renamed upload_image to upload_image_to_library for clarity.
- Removed unused parameters from upload_image_to_library.
- Introduced new endpoint for deleting images from the library.
- Created new association tables for linking images to products, services, and treatment plans.
- Updated Image model to use new association tables for relationships.
- Refactored images_service to handle new image upload and linking logic.
- Updated service and product services to use new sync_images_for_entity function.
- Added initial Alembic migration script for new database schema.